### PR TITLE
Remember last thumbnail directory

### DIFF
--- a/jdbrowser/dialogs/edit_tag_dialog.py
+++ b/jdbrowser/dialogs/edit_tag_dialog.py
@@ -1,7 +1,8 @@
+import os
 from PySide6 import QtWidgets
 from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLineEdit, QPushButton, QLabel, QFileDialog
 from PySide6.QtGui import QPixmap, QPainter, QPainterPath
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QSettings
 from ..constants import *
 
 class EditTagDialog(QDialog):
@@ -89,6 +90,10 @@ class EditTagDialog(QDialog):
         file_dialog = QFileDialog(self)
         file_dialog.setFileMode(QFileDialog.ExistingFile)
         file_dialog.setNameFilter("Images (*.png)")
+        settings = QSettings("xAI", "jdbrowser")
+        last_dir = settings.value("last_thumbnail_dir", "", type=str)
+        if last_dir:
+            file_dialog.setDirectory(last_dir)
         file_dialog.setStyleSheet(f'''
             QFileDialog {{
                 background-color: {BACKGROUND_COLOR};
@@ -157,6 +162,7 @@ class EditTagDialog(QDialog):
         ''')
         if file_dialog.exec():
             file_path = file_dialog.selectedFiles()[0]
+            settings.setValue("last_thumbnail_dir", os.path.dirname(file_path))
             pixmap = QPixmap(file_path)
             if not pixmap.isNull():
                 with open(file_path, 'rb') as f:

--- a/jdbrowser/file_browser.py
+++ b/jdbrowser/file_browser.py
@@ -79,6 +79,10 @@ class FileBrowser(QtWidgets.QMainWindow):
         file_dialog = QtWidgets.QFileDialog(self)
         file_dialog.setFileMode(QtWidgets.QFileDialog.ExistingFile)
         file_dialog.setNameFilter("Images (*.png)")
+        settings = QtCore.QSettings("xAI", "jdbrowser")
+        last_dir = settings.value("last_thumbnail_dir", "", type=str)
+        if last_dir:
+            file_dialog.setDirectory(last_dir)
         file_dialog.setStyleSheet(f'''
             QFileDialog {{
                 background-color: {BACKGROUND_COLOR};
@@ -147,6 +151,7 @@ class FileBrowser(QtWidgets.QMainWindow):
         ''')
         if file_dialog.exec():
             file_path = file_dialog.selectedFiles()[0]
+            settings.setValue("last_thumbnail_dir", os.path.dirname(file_path))
             pixmap = QtGui.QPixmap(file_path)
             if not pixmap.isNull():
                 with open(file_path, 'rb') as f:


### PR DESCRIPTION
## Summary
- persist the last directory used for selecting thumbnails in FileBrowser and EditTagDialog via `QSettings`
- reuse stored path to initialize file dialogs when picking new icons

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*
- `pip install --break-system-packages pytest` *(fails: Could not find a version that satisfies the requirement pytest)*

------
https://chatgpt.com/codex/tasks/task_e_688dc8a12564832cb0fdf99b9ac48700