### PR TITLE
Fix lastInRow NameError in file_browser

### DIFF
--- a/jdbrowser/file_browser.py
+++ b/jdbrowser/file_browser.py
@@ -814,7 +814,7 @@ class FileBrowser(QtWidgets.QMainWindow):
             sec = self.sections[self.sec_idx]
             row = self.idx_in_sec // self.cols
             length = min(self.cols, len(sec) - row * self.cols)
-            self.idx_in_sec = row * cols + length - 1
+            self.idx_in_sec = row * self.cols + length - 1
             self.desired_col = length - 1
             self.updateSelection()
 


### PR DESCRIPTION
## Summary
- prevent NameError when jumping to end of row by referencing `self.cols`

## Testing
- `PYENV_VERSION=3.11 pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dcba8e250832cbefd638ece872ca1