### PR TITLE
Add hierarchical navigation and id-based startup

### DIFF
--- a/jdbrowser/dialogs/header_dialog.py
+++ b/jdbrowser/dialogs/header_dialog.py
@@ -12,6 +12,8 @@ class HeaderDialog(QtWidgets.QDialog):
         layout.setContentsMargins(10, 10, 10, 10)
 
         row = QtWidgets.QHBoxLayout()
+        row.setSpacing(5)
+        row.setContentsMargins(0, 0, 0, 0)
         self.jd_area_input = QtWidgets.QLineEdit(str(jd_area))
         self.jd_area_input.setValidator(QtGui.QIntValidator())
         self.jd_area_input.setPlaceholderText("jd_area")
@@ -22,7 +24,6 @@ class HeaderDialog(QtWidgets.QDialog):
         self.jd_ext_input.setValidator(QtGui.QIntValidator())
         self.jd_ext_input.setPlaceholderText("jd_ext")
         for w in (self.jd_area_input, self.jd_id_input, self.jd_ext_input):
-            w.setFixedWidth(60)
             w.setStyleSheet(f"""
                 QLineEdit {{
                     background-color: {BACKGROUND_COLOR};
@@ -32,12 +33,16 @@ class HeaderDialog(QtWidgets.QDialog):
                     padding: 5px;
                 }}
             """)
-            row.addWidget(w)
+            w.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred)
         if level == 0:
-            self.jd_id_input.setEnabled(False)
-            self.jd_ext_input.setEnabled(False)
+            row.addWidget(self.jd_area_input, 1)
         elif level == 1:
-            self.jd_ext_input.setEnabled(False)
+            row.addWidget(self.jd_area_input, 1)
+            row.addWidget(self.jd_id_input, 1)
+        else:
+            row.addWidget(self.jd_area_input, 1)
+            row.addWidget(self.jd_id_input, 1)
+            row.addWidget(self.jd_ext_input, 1)
         layout.addLayout(row)
 
         self.label_input = QtWidgets.QLineEdit(label)
@@ -102,8 +107,15 @@ class HeaderDialog(QtWidgets.QDialog):
                 color: {TEXT_COLOR};
             }}
         """)
-        self.jd_area_input.setFocus()
-        self.jd_area_input.selectAll()
+        if level == 0:
+            self.jd_area_input.setFocus()
+            self.jd_area_input.selectAll()
+        elif level == 1:
+            self.jd_id_input.setFocus()
+            self.jd_id_input.selectAll()
+        else:
+            self.jd_ext_input.setFocus()
+            self.jd_ext_input.selectAll()
 
     def _on_delete(self):
         self.delete_pressed = True

--- a/jdbrowser/dialogs/header_dialog.py
+++ b/jdbrowser/dialogs/header_dialog.py
@@ -2,7 +2,7 @@ from PySide6 import QtWidgets, QtGui
 from ..constants import *
 
 class HeaderDialog(QtWidgets.QDialog):
-    def __init__(self, jd_area=0, jd_id=None, jd_ext=None, label="HEADER", show_delete=False, parent=None):
+    def __init__(self, jd_area=0, jd_id=None, jd_ext=None, label="HEADER", show_delete=False, parent=None, level=0):
         super().__init__(parent)
         self.setWindowTitle("Section Header")
         self.delete_pressed = False
@@ -22,6 +22,7 @@ class HeaderDialog(QtWidgets.QDialog):
         self.jd_ext_input.setValidator(QtGui.QIntValidator())
         self.jd_ext_input.setPlaceholderText("jd_ext")
         for w in (self.jd_area_input, self.jd_id_input, self.jd_ext_input):
+            w.setFixedWidth(60)
             w.setStyleSheet(f"""
                 QLineEdit {{
                     background-color: {BACKGROUND_COLOR};
@@ -32,6 +33,11 @@ class HeaderDialog(QtWidgets.QDialog):
                 }}
             """)
             row.addWidget(w)
+        if level == 0:
+            self.jd_id_input.setEnabled(False)
+            self.jd_ext_input.setEnabled(False)
+        elif level == 1:
+            self.jd_ext_input.setEnabled(False)
         layout.addLayout(row)
 
         self.label_input = QtWidgets.QLineEdit(label)

--- a/jdbrowser/dialogs/input_tag_dialog.py
+++ b/jdbrowser/dialogs/input_tag_dialog.py
@@ -1,8 +1,8 @@
-from PySide6 import QtWidgets, QtGui, QtCore
+from PySide6 import QtWidgets, QtGui
 from ..constants import *
 
 class InputTagDialog(QtWidgets.QDialog):
-    def __init__(self, default_jd_area, default_label, parent=None):
+    def __init__(self, default_jd_area=None, default_jd_id=None, default_jd_ext=None, default_label="", level=0, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Create Tag")
         self.setFixedWidth(300)
@@ -10,57 +10,38 @@ class InputTagDialog(QtWidgets.QDialog):
         layout.setSpacing(10)
         layout.setContentsMargins(10, 10, 10, 10)
 
-        # jd_area input
-        self.jd_area_input = QtWidgets.QLineEdit(str(default_jd_area))
-        self.jd_area_input.setPlaceholderText("Enter jd_area (integer)")
-        self.jd_area_input.setValidator(QtGui.QIntValidator())
-        self.jd_area_input.setStyleSheet(f'''
-            QLineEdit {{
-                background-color: {BACKGROUND_COLOR};
-                color: {TEXT_COLOR};
-                border: 1px solid {BORDER_COLOR};
-                border-radius: 5px;
-                padding: 5px;
-            }}
-        ''')
-        layout.addWidget(QtWidgets.QLabel("jd_area:"))
-        layout.addWidget(self.jd_area_input)
+        row = QtWidgets.QHBoxLayout()
+        self.jd_area_input = QtWidgets.QLineEdit("" if default_jd_area is None else str(default_jd_area))
+        self.jd_id_input = QtWidgets.QLineEdit("" if default_jd_id is None else str(default_jd_id))
+        self.jd_ext_input = QtWidgets.QLineEdit("" if default_jd_ext is None else str(default_jd_ext))
+        for w, placeholder in (
+            (self.jd_area_input, "jd_area"),
+            (self.jd_id_input, "jd_id"),
+            (self.jd_ext_input, "jd_ext"),
+        ):
+            w.setPlaceholderText(placeholder)
+            w.setValidator(QtGui.QIntValidator())
+            w.setFixedWidth(60)
+            w.setStyleSheet(f'''
+                QLineEdit {{
+                    background-color: {BACKGROUND_COLOR};
+                    color: {TEXT_COLOR};
+                    border: 1px solid {BORDER_COLOR};
+                    border-radius: 5px;
+                    padding: 5px;
+                }}
+            ''')
+            row.addWidget(w)
+        layout.addLayout(row)
 
-        # jd_id input (hidden for now)
-        self.jd_id_input = QtWidgets.QLineEdit()
-        self.jd_id_input.setPlaceholderText("Enter jd_id (integer, optional)")
-        self.jd_id_input.setValidator(QtGui.QIntValidator())
-        self.jd_id_input.setStyleSheet(f'''
-            QLineEdit {{
-                background-color: {BACKGROUND_COLOR};
-                color: {TEXT_COLOR};
-                border: 1px solid {BORDER_COLOR};
-                border-radius: 5px;
-                padding: 5px;
-            }}
-        ''')
-        # layout.addWidget(QtWidgets.QLabel("jd_id (optional):"))
-        # layout.addWidget(self.jd_id_input)
+        if level == 0:
+            self.jd_id_input.setEnabled(False)
+            self.jd_ext_input.setEnabled(False)
+        elif level == 1:
+            self.jd_ext_input.setEnabled(False)
 
-        # jd_ext input (hidden for now)
-        self.jd_ext_input = QtWidgets.QLineEdit()
-        self.jd_ext_input.setPlaceholderText("Enter jd_ext (integer, optional)")
-        self.jd_ext_input.setValidator(QtGui.QIntValidator())
-        self.jd_ext_input.setStyleSheet(f'''
-            QLineEdit {{
-                background-color: {BACKGROUND_COLOR};
-                color: {TEXT_COLOR};
-                border: 1px solid {BORDER_COLOR};
-                border-radius: 5px;
-                padding: 5px;
-            }}
-        ''')
-        # layout.addWidget(QtWidgets.QLabel("jd_ext (optional):"))
-        # layout.addWidget(self.jd_ext_input)
-
-        # Label input
         self.label_input = QtWidgets.QLineEdit(default_label)
-        self.label_input.setPlaceholderText("Enter tag label")
+        self.label_input.setPlaceholderText("Label")
         self.label_input.setStyleSheet(f'''
             QLineEdit {{
                 background-color: {BACKGROUND_COLOR};
@@ -70,10 +51,8 @@ class InputTagDialog(QtWidgets.QDialog):
                 padding: 5px;
             }}
         ''')
-        layout.addWidget(QtWidgets.QLabel("Label:"))
         layout.addWidget(self.label_input)
 
-        # Buttons
         buttons = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel)
         buttons.setStyleSheet(f'''
             QPushButton {{
@@ -91,7 +70,6 @@ class InputTagDialog(QtWidgets.QDialog):
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
 
-        # Style labels
         self.setStyleSheet(f'''
             QDialog {{
                 background-color: {BACKGROUND_COLOR};
@@ -101,7 +79,6 @@ class InputTagDialog(QtWidgets.QDialog):
             }}
         ''')
 
-        # Focus the label input
         self.label_input.setFocus()
 
     def get_values(self):
@@ -112,3 +89,4 @@ class InputTagDialog(QtWidgets.QDialog):
         except ValueError:
             jd_area, jd_id, jd_ext = None, None, None
         return jd_area, jd_id, jd_ext, self.label_input.text()
+

--- a/jdbrowser/dialogs/input_tag_dialog.py
+++ b/jdbrowser/dialogs/input_tag_dialog.py
@@ -11,6 +11,8 @@ class InputTagDialog(QtWidgets.QDialog):
         layout.setContentsMargins(10, 10, 10, 10)
 
         row = QtWidgets.QHBoxLayout()
+        row.setSpacing(5)
+        row.setContentsMargins(0, 0, 0, 0)
         self.jd_area_input = QtWidgets.QLineEdit("" if default_jd_area is None else str(default_jd_area))
         self.jd_id_input = QtWidgets.QLineEdit("" if default_jd_id is None else str(default_jd_id))
         self.jd_ext_input = QtWidgets.QLineEdit("" if default_jd_ext is None else str(default_jd_ext))
@@ -21,7 +23,6 @@ class InputTagDialog(QtWidgets.QDialog):
         ):
             w.setPlaceholderText(placeholder)
             w.setValidator(QtGui.QIntValidator())
-            w.setFixedWidth(60)
             w.setStyleSheet(f'''
                 QLineEdit {{
                     background-color: {BACKGROUND_COLOR};
@@ -31,14 +32,17 @@ class InputTagDialog(QtWidgets.QDialog):
                     padding: 5px;
                 }}
             ''')
-            row.addWidget(w)
-        layout.addLayout(row)
-
+            w.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred)
         if level == 0:
-            self.jd_id_input.setEnabled(False)
-            self.jd_ext_input.setEnabled(False)
+            row.addWidget(self.jd_area_input, 1)
         elif level == 1:
-            self.jd_ext_input.setEnabled(False)
+            row.addWidget(self.jd_area_input, 1)
+            row.addWidget(self.jd_id_input, 1)
+        else:
+            row.addWidget(self.jd_area_input, 1)
+            row.addWidget(self.jd_id_input, 1)
+            row.addWidget(self.jd_ext_input, 1)
+        layout.addLayout(row)
 
         self.label_input = QtWidgets.QLineEdit(default_label)
         self.label_input.setPlaceholderText("Label")

--- a/jdbrowser/file_browser.py
+++ b/jdbrowser/file_browser.py
@@ -17,13 +17,25 @@ from .database import (
 from .constants import *
 
 class FileBrowser(QtWidgets.QMainWindow):
-    def __init__(self, directory):
+    def __init__(self, start_id=None):
         super().__init__()
-        self.directory = directory
+        self.directory = start_id or ""
         self.setWindowTitle(f"File Browser - {self.directory}")
+        self.current_level = 0
+        self.current_jd_area = None
+        self.current_jd_id = None
+        if start_id:
+            parts = start_id.split('.')
+            if len(parts) == 1:
+                self.current_level = 1
+                self.current_jd_area = int(parts[0])
+            elif len(parts) == 2:
+                self.current_level = 2
+                self.current_jd_area = int(parts[0])
+                self.current_jd_id = int(parts[1])
         self.cols = 5
         self.sections = []
-        self.section_jd_areas = []  # Store base jd_area for each section
+        self.section_paths = []  # Store (jd_area, jd_id, jd_ext) for each section
         self.section_filenames = []  # Store .2do filenames for sorting
         self.sec_idx = 0
         self.idx_in_sec = 0
@@ -174,7 +186,12 @@ class FileBrowser(QtWidgets.QMainWindow):
                 self._rebuild_ui()
 
     def _create_header(self):
-        dialog = HeaderDialog(parent=self)
+        if self.current_level == 0:
+            dialog = HeaderDialog(parent=self, level=self.current_level)
+        elif self.current_level == 1:
+            dialog = HeaderDialog(self.current_jd_area, None, None, parent=self, level=self.current_level)
+        else:
+            dialog = HeaderDialog(self.current_jd_area, self.current_jd_id, None, parent=self, level=self.current_level)
         if dialog.exec() == QtWidgets.QDialog.Accepted and not dialog.delete_pressed:
             jd_area, jd_id, jd_ext, label = dialog.get_values()
             if jd_area is None:
@@ -186,17 +203,34 @@ class FileBrowser(QtWidgets.QMainWindow):
                 self._rebuild_ui()
 
     def _append_tag_to_section(self):
-        """Append a tag to the current section with jd_area = max + 1 or section base."""
+        """Append a tag to the current section with jd parts incremented appropriately."""
         if not self.sections or self.sec_idx >= len(self.sections):
             return
         cursor = self.conn.cursor()
-        jd_area = self.section_jd_areas[self.sec_idx]
-        cursor.execute("SELECT MAX(jd_area) FROM state_tags WHERE jd_area >= ? AND jd_area < ?", (jd_area, jd_area + 10))
-        max_jd_area = cursor.fetchone()[0]
-        new_jd_area = max_jd_area + 1 if max_jd_area is not None else jd_area
+        jd_area, jd_id, jd_ext = self.section_paths[self.sec_idx]
         label = "NewTag"
-        new_tag_id = create_tag(self.conn, new_jd_area, None, None, label)
-        if new_tag_id:  # Only rebuild if tag was created successfully
+        if self.current_level == 0:
+            cursor.execute(
+                "SELECT MAX(jd_area) FROM state_tags WHERE jd_area >= ? AND jd_area < ?",
+                (jd_area, jd_area + 10),
+            )
+            max_jd_area = cursor.fetchone()[0]
+            new_jd_area = max_jd_area + 1 if max_jd_area is not None else jd_area
+            new_tag_id = create_tag(self.conn, new_jd_area, None, None, label)
+        elif self.current_level == 1:
+            cursor.execute("SELECT MAX(jd_id) FROM state_tags WHERE jd_area = ?", (jd_area,))
+            max_jd_id = cursor.fetchone()[0]
+            new_jd_id = max_jd_id + 1 if max_jd_id is not None else 0
+            new_tag_id = create_tag(self.conn, jd_area, new_jd_id, None, label)
+        else:
+            cursor.execute(
+                "SELECT MAX(jd_ext) FROM state_tags WHERE jd_area = ? AND jd_id = ?",
+                (jd_area, jd_id),
+            )
+            max_jd_ext = cursor.fetchone()[0]
+            new_jd_ext = max_jd_ext + 1 if max_jd_ext is not None else 0
+            new_tag_id = create_tag(self.conn, jd_area, jd_id, new_jd_ext, label)
+        if new_tag_id:
             rebuild_state_tags(self.conn)
             self._rebuild_ui(new_tag_id=new_tag_id)
 
@@ -205,13 +239,30 @@ class FileBrowser(QtWidgets.QMainWindow):
         if not self.sections or self.sec_idx >= len(self.sections):
             return
         cursor = self.conn.cursor()
-        jd_area = self.section_jd_areas[self.sec_idx]
-        cursor.execute("SELECT MAX(jd_area) FROM state_tags WHERE jd_area >= ? AND jd_area < ?", (jd_area, jd_area + 10))
-        max_jd_area = cursor.fetchone()[0]
-        default_jd_area = max_jd_area + 1 if max_jd_area is not None else jd_area
+        jd_area, jd_id, jd_ext = self.section_paths[self.sec_idx]
         default_label = "NewTag"
+        if self.current_level == 0:
+            cursor.execute(
+                "SELECT MAX(jd_area) FROM state_tags WHERE jd_area >= ? AND jd_area < ?",
+                (jd_area, jd_area + 10),
+            )
+            max_jd_area = cursor.fetchone()[0]
+            default_jd_area = max_jd_area + 1 if max_jd_area is not None else jd_area
+            dialog = InputTagDialog(default_jd_area, None, None, default_label, level=0, parent=self)
+        elif self.current_level == 1:
+            cursor.execute("SELECT MAX(jd_id) FROM state_tags WHERE jd_area = ?", (jd_area,))
+            max_jd_id = cursor.fetchone()[0]
+            default_jd_id = max_jd_id + 1 if max_jd_id is not None else 0
+            dialog = InputTagDialog(jd_area, default_jd_id, None, default_label, level=1, parent=self)
+        else:
+            cursor.execute(
+                "SELECT MAX(jd_ext) FROM state_tags WHERE jd_area = ? AND jd_id = ?",
+                (jd_area, jd_id),
+            )
+            max_jd_ext = cursor.fetchone()[0]
+            default_jd_ext = max_jd_ext + 1 if max_jd_ext is not None else 0
+            dialog = InputTagDialog(jd_area, jd_id, default_jd_ext, default_label, level=2, parent=self)
         while True:
-            dialog = InputTagDialog(default_jd_area, default_label, self)
             if dialog.exec() == QtWidgets.QDialog.Accepted:
                 jd_area, jd_id, jd_ext, label = dialog.get_values()
                 if jd_area is None:
@@ -232,7 +283,11 @@ class FileBrowser(QtWidgets.QMainWindow):
                     self._rebuild_ui(new_tag_id=new_tag_id)
                     break
                 else:
-                    QtWidgets.QMessageBox.warning(self, "Constraint Violation", f"The combination (jd_area={jd_area}, jd_id={jd_id}, jd_ext={jd_ext}) is already in use.")
+                    QtWidgets.QMessageBox.warning(
+                        self,
+                        "Constraint Violation",
+                        f"The combination (jd_area={jd_area}, jd_id={jd_id}, jd_ext={jd_ext}) is already in use.",
+                    )
             else:
                 break
 
@@ -329,7 +384,15 @@ class FileBrowser(QtWidgets.QMainWindow):
             self._rebuild_ui()
 
     def _edit_header(self, header_item):
-        dialog = HeaderDialog(header_item.jd_area, header_item.jd_id, header_item.jd_ext, header_item.label, True, self)
+        dialog = HeaderDialog(
+            header_item.jd_area,
+            header_item.jd_id,
+            header_item.jd_ext,
+            header_item.label,
+            True,
+            self,
+            level=self.current_level,
+        )
         if dialog.exec() == QtWidgets.QDialog.Accepted:
             if dialog.delete_pressed:
                 delete_header(self.conn, header_item.header_id)
@@ -378,15 +441,48 @@ class FileBrowser(QtWidgets.QMainWindow):
         mainLayout.setContentsMargins(5, 5, 5, 5)
 
         self.sections = []
-        self.section_jd_areas = []
+        self.section_paths = []
         self.section_filenames = []
         current_section = None
         section_index = 0
         cursor = self.conn.cursor()
-        cursor.execute("SELECT header_id, jd_area, jd_id, jd_ext, label FROM state_headers ORDER BY jd_area, jd_id, jd_ext")
-        headers = cursor.fetchall()
-        cursor.execute("SELECT tag_id, jd_area, jd_id, jd_ext, label FROM state_tags ORDER BY jd_area, jd_id, jd_ext")
-        tags = cursor.fetchall()
+        if self.current_level == 0:
+            cursor.execute(
+                "SELECT header_id, jd_area, jd_id, jd_ext, label FROM state_headers "
+                "WHERE jd_area IS NOT NULL AND jd_id IS NULL AND jd_ext IS NULL ORDER BY jd_area"
+            )
+            headers = cursor.fetchall()
+            cursor.execute(
+                "SELECT tag_id, jd_area, jd_id, jd_ext, label FROM state_tags "
+                "WHERE jd_area IS NOT NULL AND jd_id IS NULL AND jd_ext IS NULL ORDER BY jd_area"
+            )
+            tags = cursor.fetchall()
+        elif self.current_level == 1:
+            cursor.execute(
+                "SELECT header_id, jd_area, jd_id, jd_ext, label FROM state_headers "
+                "WHERE jd_area = ? AND jd_id IS NOT NULL AND jd_ext IS NULL ORDER BY jd_id",
+                (self.current_jd_area,),
+            )
+            headers = cursor.fetchall()
+            cursor.execute(
+                "SELECT tag_id, jd_area, jd_id, jd_ext, label FROM state_tags "
+                "WHERE jd_area = ? AND jd_id IS NOT NULL AND jd_ext IS NULL ORDER BY jd_id",
+                (self.current_jd_area,),
+            )
+            tags = cursor.fetchall()
+        else:
+            cursor.execute(
+                "SELECT header_id, jd_area, jd_id, jd_ext, label FROM state_headers "
+                "WHERE jd_area = ? AND jd_id = ? AND jd_ext IS NOT NULL ORDER BY jd_ext",
+                (self.current_jd_area, self.current_jd_id),
+            )
+            headers = cursor.fetchall()
+            cursor.execute(
+                "SELECT tag_id, jd_area, jd_id, jd_ext, label FROM state_tags "
+                "WHERE jd_area = ? AND jd_id = ? AND jd_ext IS NOT NULL ORDER BY jd_ext",
+                (self.current_jd_area, self.current_jd_id),
+            )
+            tags = cursor.fetchall()
         cursor.execute("SELECT tag_id, icon FROM state_tag_icons")
         icons = {row[0]: row[1] for row in cursor.fetchall()}
 
@@ -401,8 +497,6 @@ class FileBrowser(QtWidgets.QMainWindow):
 
         items = []
         for header_id, jd_area, jd_id, jd_ext, label in headers:
-            if jd_area is None or jd_id is not None or jd_ext is not None:
-                continue
             prefix = construct_prefix(jd_area, jd_id, jd_ext)
             items.append(("header", prefix, label, header_id, jd_area, jd_id, jd_ext))
         for tag_id, jd_area, jd_id, jd_ext, label in tags:
@@ -453,23 +547,34 @@ class FileBrowser(QtWidgets.QMainWindow):
                 header_item.setMinimumWidth(self.scroll.viewport().width() - 10)
                 mainLayout.addWidget(header_item)
                 mainLayout.addSpacing(10)
-                self.section_jd_areas.append(jd_area)
+                self.section_paths.append((jd_area, jd_id, jd_ext))
                 self.section_filenames.append(obj_id)
                 current_section = []
             else:
                 if current_section is None:
-                    self.section_jd_areas.append(jd_area if jd_area is not None else 0)
+                    self.section_paths.append((jd_area, jd_id, jd_ext))
                     self.section_filenames.append(obj_id)
                     current_section = []
                 icon_data = icons.get(obj_id)
-                item = FileItem(obj_id, label, jd_area, jd_id, jd_ext, icon_data, self.directory, self, section_index, len(current_section))
+                item = FileItem(
+                    obj_id,
+                    label,
+                    jd_area,
+                    jd_id,
+                    jd_ext,
+                    icon_data,
+                    self.directory,
+                    self,
+                    section_index,
+                    len(current_section),
+                )
                 current_section.append(item)
 
         flush_section()
         if not items:
             placeholder = FileItem(None, None, None, None, None, None, self.directory, self, 0, 0)
             add_section([placeholder])
-            self.section_jd_areas.append(0)
+            self.section_paths.append((None, None, None))
             self.section_filenames.append(None)
 
         mainLayout.addStretch()
@@ -516,7 +621,7 @@ class FileBrowser(QtWidgets.QMainWindow):
         if old_widget:
             old_widget.deleteLater()
         self.sections = []
-        self.section_jd_areas = []
+        self.section_paths = []
         self.section_filenames = []
         self._setup_ui()
         # Try to select the new tag or fall back to the previous selection
@@ -577,12 +682,14 @@ class FileBrowser(QtWidgets.QMainWindow):
             (QtCore.Qt.Key_S, self._create_header, None),
             (QtCore.Qt.Key_A, self._append_tag_to_section, None),
             (QtCore.Qt.Key_I, self._input_tag_dialog, None),
-            (QtCore.Qt.Key_C, self._edit_tag_label_with_icon, None),
-            (QtCore.Qt.Key_R, self._rename_tag_label, None),
-            (QtCore.Qt.Key_F2, self._rename_tag_label, None),
-            (QtCore.Qt.Key_D, self._delete_tag, None),
-            (QtCore.Qt.Key_T, self._set_thumbnail, None),
-        ]
+              (QtCore.Qt.Key_C, self._edit_tag_label_with_icon, None),
+              (QtCore.Qt.Key_R, self._rename_tag_label, None),
+              (QtCore.Qt.Key_F2, self._rename_tag_label, None),
+              (QtCore.Qt.Key_D, self._delete_tag, None),
+              (QtCore.Qt.Key_T, self._set_thumbnail, None),
+              (QtCore.Qt.Key_Return, self.descend_level, None),
+              (QtCore.Qt.Key_Enter, self.descend_level, None),
+          ]
         quit_keys = ['Q', 'Ctrl+Q', 'Ctrl+W', 'Alt+F4']
         self.shortcuts = []
         for mapping in self.normal_shortcuts:
@@ -806,6 +913,25 @@ class FileBrowser(QtWidgets.QMainWindow):
             self.idx_in_sec = row * self.cols + length - 1
             self.desired_col = length - 1
             self.updateSelection()
+
+    def descend_level(self):
+        if not self.sections or self.sec_idx >= len(self.sections) or self.idx_in_sec >= len(self.sections[self.sec_idx]):
+            return
+        current = self.sections[self.sec_idx][self.idx_in_sec]
+        if not current.tag_id:
+            return
+        if self.current_level == 0:
+            self.current_jd_area = current.jd_area
+            self.current_level = 1
+            self.sec_idx = 0
+            self.idx_in_sec = 0
+            self._rebuild_ui()
+        elif self.current_level == 1 and current.jd_id is not None:
+            self.current_jd_id = current.jd_id
+            self.current_level = 2
+            self.sec_idx = 0
+            self.idx_in_sec = 0
+            self._rebuild_ui()
 
     def updateSelection(self):
         if self.sections and 0 <= self.sec_idx < len(self.sections) and 0 <= self.idx_in_sec < len(self.sections[self.sec_idx]):

--- a/main.py
+++ b/main.py
@@ -1,9 +1,8 @@
-import os
 import sys
 import signal
+import re
 from PySide6 import QtCore
 from PySide6.QtWidgets import QApplication
-from jdbrowser.config import read_config
 from jdbrowser.file_browser import FileBrowser
 from PySide6.QtCore import QSettings, QPoint, QSize
 from PySide6.QtGui import QFont
@@ -12,18 +11,14 @@ from PySide6.QtGui import QFont
 signal.signal(signal.SIGINT, lambda sig, frame: QApplication.quit())
 
 if __name__ == '__main__':
-    if len(sys.argv) > 1:
-        directory = sys.argv[1]
-    else:
-        directory = read_config()
-    directory = os.path.expanduser(directory)
-    if not os.path.isdir(directory):
-        print('Error:', directory, 'is not a valid directory.')
+    start_id = sys.argv[1] if len(sys.argv) > 1 else None
+    if start_id and not re.match(r'^\d{2}(\.\d{2})?$', start_id):
+        print('Error:', start_id, 'is not a valid id. Use XX or XX.YY.')
         sys.exit(1)
 
     app = QApplication(sys.argv)
     app.setFont(QFont('FiraCode Nerd Font'))
-    browser = FileBrowser(directory)
+    browser = FileBrowser(start_id)
     settings = QSettings("xAI", "jdbrowser")
     if not (settings.contains("pos") and settings.contains("size")):
         browser.resize(1000, 600)


### PR DESCRIPTION
## Summary
- Allow launching the browser at a specific id level (XX or XX.YY)
- Implement multi-level navigation for jd_area → jd_id → jd_ext with Enter key
- Simplify tag/header dialogs to show jd parts on one line with level-aware fields

## Testing
- `python3 -m py_compile main.py jdbrowser/file_browser.py jdbrowser/dialogs/input_tag_dialog.py jdbrowser/dialogs/header_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_688ddeafd3ec832c8b2a0cdc1c079f61