### PR TITLE
Fill placeholder defaults when using i shortcut

### DIFF
--- a/jdbrowser/file_browser.py
+++ b/jdbrowser/file_browser.py
@@ -275,6 +275,14 @@ class FileBrowser(QtWidgets.QMainWindow):
         """Open a dialog to input jd_area, jd_id, jd_ext, and label for a new tag."""
         if not self.sections or self.sec_idx >= len(self.sections):
             return
+        # If the current selection is a placeholder, reuse the same behaviour as
+        # the 'c' shortcut or right-click: pre-fill the dialog with the
+        # placeholder's prefix values.
+        if self.idx_in_sec < len(self.sections[self.sec_idx]):
+            current_item = self.sections[self.sec_idx][self.idx_in_sec]
+            if not current_item.tag_id:  # placeholder item
+                self._edit_tag_label_with_icon()
+                return
         cursor = self.conn.cursor()
         jd_area, jd_id, jd_ext = self.section_paths[self.sec_idx]
         default_label = "NewTag"


### PR DESCRIPTION
## Summary
- Prefill InputTagDialog with placeholder prefix when pressing `i`

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ed6d14c44832c97110a51a1e02008