### PR TITLE
Add level-aware prefix field to tag dialogs

### DIFF
--- a/jdbrowser/dialogs/edit_tag_dialog.py
+++ b/jdbrowser/dialogs/edit_tag_dialog.py
@@ -2,7 +2,7 @@ import os
 from PySide6 import QtWidgets
 from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLineEdit, QPushButton, QLabel, QFileDialog
 from PySide6.QtGui import QPixmap, QPainter, QPainterPath, QIntValidator
-from PySide6.QtCore import Qt, QSettings
+from PySide6.QtCore import Qt, QSettings, QTimer
 from ..constants import *
 
 
@@ -70,19 +70,15 @@ class EditTagDialog(QDialog):
         default_prefix = [jd_area, jd_id, jd_ext][level]
         placeholder = ["jd_area", "jd_id", "jd_ext"][level]
         self.prefix_input = QLineEdit("" if default_prefix is None else str(default_prefix))
-        self.prefix_input.setMinimumWidth(240)
         self.prefix_input.setPlaceholderText(placeholder)
         self.prefix_input.setValidator(QIntValidator())
         self.prefix_input.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Fixed)
-        layout.addWidget(self.prefix_input, alignment=Qt.AlignmentFlag.AlignHCenter)
+        layout.addWidget(self.prefix_input)
 
         # Label input (below prefix, full width)
         self.input = QLineEdit(current_label)
-        self.input.setMinimumWidth(240)  # Match thumbnail width
         self.input.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Fixed)
-        self.input.selectAll()  # Select all text in the input box
-        self.input.setFocus()  # Focus label field by default
-        layout.addWidget(self.input, alignment=Qt.AlignmentFlag.AlignHCenter)
+        layout.addWidget(self.input)
 
         # Buttons (side-by-side, half-width each)
         button_layout = QHBoxLayout()
@@ -100,6 +96,13 @@ class EditTagDialog(QDialog):
         layout.addLayout(button_layout)
 
         self.setFixedSize(self.sizeHint())
+
+        # ensure the label field is focused and preselected once the dialog shows
+        QTimer.singleShot(0, self._focus_label)
+
+    def _focus_label(self):
+        self.input.setFocus()
+        self.input.selectAll()
 
     def change_icon(self, event=None):
         file_dialog = QFileDialog(self)

--- a/jdbrowser/dialogs/edit_tag_dialog.py
+++ b/jdbrowser/dialogs/edit_tag_dialog.py
@@ -81,6 +81,7 @@ class EditTagDialog(QDialog):
         self.input.setMinimumWidth(240)  # Match thumbnail width
         self.input.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Fixed)
         self.input.selectAll()  # Select all text in the input box
+        self.input.setFocus()  # Focus label field by default
         layout.addWidget(self.input, alignment=Qt.AlignmentFlag.AlignHCenter)
 
         # Buttons (side-by-side, half-width each)

--- a/jdbrowser/dialogs/input_tag_dialog.py
+++ b/jdbrowser/dialogs/input_tag_dialog.py
@@ -1,6 +1,7 @@
 from PySide6 import QtWidgets, QtGui
 from ..constants import *
 
+
 class InputTagDialog(QtWidgets.QDialog):
     def __init__(self, default_jd_area=None, default_jd_id=None, default_jd_ext=None, default_label="", level=0, parent=None):
         super().__init__(parent)
@@ -10,39 +11,25 @@ class InputTagDialog(QtWidgets.QDialog):
         layout.setSpacing(10)
         layout.setContentsMargins(10, 10, 10, 10)
 
-        row = QtWidgets.QHBoxLayout()
-        row.setSpacing(5)
-        row.setContentsMargins(0, 0, 0, 0)
-        self.jd_area_input = QtWidgets.QLineEdit("" if default_jd_area is None else str(default_jd_area))
-        self.jd_id_input = QtWidgets.QLineEdit("" if default_jd_id is None else str(default_jd_id))
-        self.jd_ext_input = QtWidgets.QLineEdit("" if default_jd_ext is None else str(default_jd_ext))
-        for w, placeholder in (
-            (self.jd_area_input, "jd_area"),
-            (self.jd_id_input, "jd_id"),
-            (self.jd_ext_input, "jd_ext"),
-        ):
-            w.setPlaceholderText(placeholder)
-            w.setValidator(QtGui.QIntValidator())
-            w.setStyleSheet(f'''
-                QLineEdit {{
-                    background-color: {BACKGROUND_COLOR};
-                    color: {TEXT_COLOR};
-                    border: 1px solid {BORDER_COLOR};
-                    border-radius: 5px;
-                    padding: 5px;
-                }}
-            ''')
-            w.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred)
-        if level == 0:
-            row.addWidget(self.jd_area_input, 1)
-        elif level == 1:
-            row.addWidget(self.jd_area_input, 1)
-            row.addWidget(self.jd_id_input, 1)
-        else:
-            row.addWidget(self.jd_area_input, 1)
-            row.addWidget(self.jd_id_input, 1)
-            row.addWidget(self.jd_ext_input, 1)
-        layout.addLayout(row)
+        self.level = level
+        self.fixed_jd_area = default_jd_area if level >= 1 else None
+        self.fixed_jd_id = default_jd_id if level >= 2 else None
+        default_prefix = [default_jd_area, default_jd_id, default_jd_ext][level]
+        placeholder = ["jd_area", "jd_id", "jd_ext"][level]
+        self.prefix_input = QtWidgets.QLineEdit("" if default_prefix is None else str(default_prefix))
+        self.prefix_input.setPlaceholderText(placeholder)
+        self.prefix_input.setValidator(QtGui.QIntValidator())
+        self.prefix_input.setStyleSheet(f'''
+            QLineEdit {{
+                background-color: {BACKGROUND_COLOR};
+                color: {TEXT_COLOR};
+                border: 1px solid {BORDER_COLOR};
+                border-radius: 5px;
+                padding: 5px;
+            }}
+        ''')
+        self.prefix_input.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred)
+        layout.addWidget(self.prefix_input)
 
         self.label_input = QtWidgets.QLineEdit(default_label)
         self.label_input.setPlaceholderText("Label")
@@ -87,10 +74,14 @@ class InputTagDialog(QtWidgets.QDialog):
 
     def get_values(self):
         try:
-            jd_area = int(self.jd_area_input.text()) if self.jd_area_input.text() else None
-            jd_id = int(self.jd_id_input.text()) if self.jd_id_input.text() else None
-            jd_ext = int(self.jd_ext_input.text()) if self.jd_ext_input.text() else None
+            prefix = int(self.prefix_input.text()) if self.prefix_input.text() else None
         except ValueError:
-            jd_area, jd_id, jd_ext = None, None, None
+            prefix = None
+        if self.level == 0:
+            jd_area, jd_id, jd_ext = prefix, None, None
+        elif self.level == 1:
+            jd_area, jd_id, jd_ext = self.fixed_jd_area, prefix, None
+        else:
+            jd_area, jd_id, jd_ext = self.fixed_jd_area, self.fixed_jd_id, prefix
         return jd_area, jd_id, jd_ext, self.label_input.text()
 

--- a/jdbrowser/dialogs/input_tag_dialog.py
+++ b/jdbrowser/dialogs/input_tag_dialog.py
@@ -71,6 +71,7 @@ class InputTagDialog(QtWidgets.QDialog):
         ''')
 
         self.label_input.setFocus()
+        self.label_input.selectAll()
 
     def get_values(self):
         try:

--- a/jdbrowser/file_browser.py
+++ b/jdbrowser/file_browser.py
@@ -64,6 +64,31 @@ class FileBrowser(QtWidgets.QMainWindow):
         # Disable window decorations
         self.setWindowFlags(QtCore.Qt.FramelessWindowHint)
 
+        app = QtWidgets.QApplication.instance()
+        if app:
+            app.setStyleSheet(
+                app.styleSheet()
+                + f"""
+                QMessageBox {{
+                    background-color: {BACKGROUND_COLOR};
+                    color: {TEXT_COLOR};
+                }}
+                QMessageBox QLabel {{
+                    color: {TEXT_COLOR};
+                }}
+                QMessageBox QPushButton {{
+                    background-color: {BUTTON_COLOR};
+                    color: black;
+                    border: none;
+                    padding: 5px;
+                    border-radius: 5px;
+                }}
+                QMessageBox QPushButton:hover {{
+                    background-color: {HIGHLIGHT_COLOR};
+                }}
+                """
+            )
+
         self._setup_ui()
         self._setup_shortcuts()
         self.updateSelection()

--- a/jdbrowser/file_browser.py
+++ b/jdbrowser/file_browser.py
@@ -72,6 +72,7 @@ class FileBrowser(QtWidgets.QMainWindow):
                 QMessageBox {{
                     background-color: {BACKGROUND_COLOR};
                     color: {TEXT_COLOR};
+                    border: 1px solid {BORDER_COLOR};
                 }}
                 QMessageBox QLabel {{
                     color: {TEXT_COLOR};
@@ -85,6 +86,9 @@ class FileBrowser(QtWidgets.QMainWindow):
                 }}
                 QMessageBox QPushButton:hover {{
                     background-color: {HIGHLIGHT_COLOR};
+                }}
+                QMessageBox QPushButton:pressed {{
+                    background-color: {HOVER_COLOR};
                 }}
                 """
             )

--- a/jdbrowser/file_browser.py
+++ b/jdbrowser/file_browser.py
@@ -109,6 +109,38 @@ class FileBrowser(QtWidgets.QMainWindow):
             self.idx_in_sec = item_idx
             self.updateSelection()
 
+    def _warn(self, title: str, message: str) -> None:
+        box = QtWidgets.QMessageBox(self)
+        box.setIcon(QtWidgets.QMessageBox.Warning)
+        box.setWindowTitle(title)
+        box.setText(message)
+        box.setStyleSheet(
+            f"""
+            QMessageBox {{
+                background-color: {BACKGROUND_COLOR};
+                color: {TEXT_COLOR};
+                border: 1px solid {BORDER_COLOR};
+            }}
+            QLabel {{
+                color: {TEXT_COLOR};
+            }}
+            QPushButton {{
+                background-color: {BUTTON_COLOR};
+                color: black;
+                border: none;
+                padding: 5px;
+                border-radius: 5px;
+            }}
+            QPushButton:hover {{
+                background-color: {HIGHLIGHT_COLOR};
+            }}
+            QPushButton:pressed {{
+                background-color: {HOVER_COLOR};
+            }}
+            """
+        )
+        box.exec()
+
     def _is_hidden_item(self, name):
         """Check if an item should be hidden based on naming patterns."""
         if self.show_hidden:
@@ -240,7 +272,7 @@ class FileBrowser(QtWidgets.QMainWindow):
         if dialog.exec() == QtWidgets.QDialog.Accepted and not dialog.delete_pressed:
             jd_area, jd_id, jd_ext, label = dialog.get_values()
             if jd_area is None:
-                QtWidgets.QMessageBox.warning(self, "Invalid Input", "jd_area must be an integer.")
+                self._warn("Invalid Input", "jd_area must be an integer.")
                 return
             header_id = create_header(self.conn, jd_area, jd_id, jd_ext, label)
             if header_id:
@@ -365,17 +397,16 @@ class FileBrowser(QtWidgets.QMainWindow):
                     or (self.current_level == 1 and jd_id is None)
                     or (self.current_level == 2 and jd_ext is None)
                 ):
-                    QtWidgets.QMessageBox.warning(
-                        self,
+                    self._warn(
                         "Invalid Input",
                         ["jd_area", "jd_id", "jd_ext"][self.current_level] + " must be an integer.",
                     )
                     continue
                 if jd_id is not None and jd_area is None:
-                    QtWidgets.QMessageBox.warning(self, "Invalid Input", "jd_id requires jd_area.")
+                    self._warn("Invalid Input", "jd_id requires jd_area.")
                     continue
                 if jd_ext is not None and jd_id is None:
-                    QtWidgets.QMessageBox.warning(self, "Invalid Input", "jd_ext requires jd_id.")
+                    self._warn("Invalid Input", "jd_ext requires jd_id.")
                     continue
                 new_tag_id = create_tag(self.conn, jd_area, jd_id, jd_ext, label)
                 if new_tag_id:
@@ -383,8 +414,7 @@ class FileBrowser(QtWidgets.QMainWindow):
                     self._rebuild_ui(new_tag_id=new_tag_id)
                     break
                 else:
-                    QtWidgets.QMessageBox.warning(
-                        self,
+                    self._warn(
                         "Constraint Violation",
                         f"The combination (jd_area={jd_area}, jd_id={jd_id}, jd_ext={jd_ext}) is already in use.",
                     )
@@ -419,17 +449,16 @@ class FileBrowser(QtWidgets.QMainWindow):
                         or (self.current_level == 1 and jd_id is None)
                         or (self.current_level == 2 and jd_ext is None)
                     ):
-                        QtWidgets.QMessageBox.warning(
-                            self,
+                        self._warn(
                             "Invalid Input",
                             ["jd_area", "jd_id", "jd_ext"][self.current_level] + " must be an integer.",
                         )
                         continue
                     if jd_id is not None and jd_area is None:
-                        QtWidgets.QMessageBox.warning(self, "Invalid Input", "jd_id requires jd_area.")
+                        self._warn("Invalid Input", "jd_id requires jd_area.")
                         continue
                     if jd_ext is not None and jd_id is None:
-                        QtWidgets.QMessageBox.warning(self, "Invalid Input", "jd_ext requires jd_id.")
+                        self._warn("Invalid Input", "jd_ext requires jd_id.")
                         continue
                     new_tag_id = create_tag(self.conn, jd_area, jd_id, jd_ext, label)
                     if new_tag_id:
@@ -437,8 +466,7 @@ class FileBrowser(QtWidgets.QMainWindow):
                         self._rebuild_ui(new_tag_id=new_tag_id)
                         break
                     else:
-                        QtWidgets.QMessageBox.warning(
-                            self,
+                        self._warn(
                             "Constraint Violation",
                             f"The combination (jd_area={jd_area}, jd_id={jd_id}, jd_ext={jd_ext}) is already in use.",
                         )
@@ -463,8 +491,7 @@ class FileBrowser(QtWidgets.QMainWindow):
                     or (self.current_level == 1 and new_jd_id is None)
                     or (self.current_level == 2 and new_jd_ext is None)
                 ):
-                    QtWidgets.QMessageBox.warning(
-                        self,
+                    self._warn(
                         "Invalid Input",
                         ["jd_area", "jd_id", "jd_ext"][self.current_level] + " must be an integer.",
                     )
@@ -472,12 +499,12 @@ class FileBrowser(QtWidgets.QMainWindow):
                     jd_area, jd_id, jd_ext = new_jd_area, new_jd_id, new_jd_ext
                     continue
                 if new_jd_id is not None and new_jd_area is None:
-                    QtWidgets.QMessageBox.warning(self, "Invalid Input", "jd_id requires jd_area.")
+                    self._warn("Invalid Input", "jd_id requires jd_area.")
                     current_label, icon_data = new_label, new_icon_data
                     jd_area, jd_id, jd_ext = new_jd_area, new_jd_id, new_jd_ext
                     continue
                 if new_jd_ext is not None and new_jd_id is None:
-                    QtWidgets.QMessageBox.warning(self, "Invalid Input", "jd_ext requires jd_id.")
+                    self._warn("Invalid Input", "jd_ext requires jd_id.")
                     current_label, icon_data = new_label, new_icon_data
                     jd_area, jd_id, jd_ext = new_jd_area, new_jd_id, new_jd_ext
                     continue
@@ -486,8 +513,7 @@ class FileBrowser(QtWidgets.QMainWindow):
                     (new_jd_area, new_jd_id, new_jd_ext, tag_id),
                 )
                 if cursor.fetchone():
-                    QtWidgets.QMessageBox.warning(
-                        self,
+                    self._warn(
                         "Constraint Violation",
                         f"The combination (jd_area={new_jd_area}, jd_id={new_jd_id}, jd_ext={new_jd_ext}) is already in use.",
                     )
@@ -592,10 +618,10 @@ class FileBrowser(QtWidgets.QMainWindow):
             else:
                 jd_area, jd_id, jd_ext, label = dialog.get_values()
                 if jd_area is None:
-                    QtWidgets.QMessageBox.warning(self, "Invalid Input", "jd_area must be an integer.")
+                    self._warn("Invalid Input", "jd_area must be an integer.")
                     return
                 if not update_header(self.conn, header_item.header_id, jd_area, jd_id, jd_ext, label):
-                    QtWidgets.QMessageBox.warning(self, "Invalid Input", "Header path conflicts or invalid.")
+                    self._warn("Invalid Input", "Header path conflicts or invalid.")
                     return
             rebuild_state_headers(self.conn)
             self._rebuild_ui()

--- a/jdbrowser/file_browser.py
+++ b/jdbrowser/file_browser.py
@@ -122,7 +122,12 @@ class FileBrowser(QtWidgets.QMainWindow):
                 border: 1px solid {BORDER_COLOR};
             }}
             QLabel {{
+                background-color: transparent;
                 color: {TEXT_COLOR};
+            }}
+            QLabel#qt_msgbox_label,
+            QLabel#qt_msgboxex_icon_label {{
+                background-color: transparent;
             }}
             QPushButton {{
                 background-color: {BUTTON_COLOR};


### PR DESCRIPTION
## Summary
- simplify tag creation dialog to a single prefix input that maps to jd_area, jd_id, or jd_ext based on the current level
- extend tag edit dialog with a matching prefix field and return full path details
- update file browser logic to validate level-aware prefix edits and persist path changes

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 -m pytest -q` *(fails: No module named pytest; pip install blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688ed9577678832cb1aaa3b60155d133