### PR TITLE
Simplify header dialog to single prefix field

### DIFF
--- a/jdbrowser/dialogs/header_dialog.py
+++ b/jdbrowser/dialogs/header_dialog.py
@@ -1,53 +1,53 @@
 from PySide6 import QtWidgets, QtGui
 from ..constants import *
 
+
 class HeaderDialog(QtWidgets.QDialog):
-    def __init__(self, jd_area=0, jd_id=None, jd_ext=None, label="HEADER", show_delete=False, parent=None, level=0):
+    def __init__(
+        self,
+        jd_area=0,
+        jd_id=None,
+        jd_ext=None,
+        label="HEADER",
+        show_delete=False,
+        parent=None,
+        level=0,
+    ):
         super().__init__(parent)
         self.setWindowTitle("Section Header")
         self.delete_pressed = False
         self.setFixedWidth(300)
+
+        # Store the incoming values so they can be returned for levels that hide
+        # those fields.
+        self.level = level
+        self.jd_area = jd_area
+        self.jd_id = jd_id
+        self.jd_ext = jd_ext
+
         layout = QtWidgets.QVBoxLayout(self)
         layout.setSpacing(10)
         layout.setContentsMargins(10, 10, 10, 10)
 
-        row = QtWidgets.QHBoxLayout()
-        row.setSpacing(5)
-        row.setContentsMargins(0, 0, 0, 0)
-        self.jd_area_input = QtWidgets.QLineEdit(str(jd_area))
-        self.jd_area_input.setValidator(QtGui.QIntValidator())
-        self.jd_area_input.setPlaceholderText("jd_area")
-        self.jd_id_input = QtWidgets.QLineEdit("" if jd_id is None else str(jd_id))
-        self.jd_id_input.setValidator(QtGui.QIntValidator())
-        self.jd_id_input.setPlaceholderText("jd_id")
-        self.jd_ext_input = QtWidgets.QLineEdit("" if jd_ext is None else str(jd_ext))
-        self.jd_ext_input.setValidator(QtGui.QIntValidator())
-        self.jd_ext_input.setPlaceholderText("jd_ext")
-        for w in (self.jd_area_input, self.jd_id_input, self.jd_ext_input):
-            w.setStyleSheet(f"""
-                QLineEdit {{
-                    background-color: {BACKGROUND_COLOR};
-                    color: {TEXT_COLOR};
-                    border: 1px solid {BORDER_COLOR};
-                    border-radius: 5px;
-                    padding: 5px;
-                }}
-            """)
-            w.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred)
+        # Single prefix input depending on the level being edited. The width of
+        # the field is set to expand to 100% of the dialog width.
         if level == 0:
-            row.addWidget(self.jd_area_input, 1)
+            prefix_val = jd_area
+            placeholder = "jd_area"
         elif level == 1:
-            row.addWidget(self.jd_area_input, 1)
-            row.addWidget(self.jd_id_input, 1)
+            prefix_val = jd_id
+            placeholder = "jd_id"
         else:
-            row.addWidget(self.jd_area_input, 1)
-            row.addWidget(self.jd_id_input, 1)
-            row.addWidget(self.jd_ext_input, 1)
-        layout.addLayout(row)
+            prefix_val = jd_ext
+            placeholder = "jd_ext"
 
-        self.label_input = QtWidgets.QLineEdit(label)
-        self.label_input.setPlaceholderText("Label")
-        self.label_input.setStyleSheet(f"""
+        self.prefix_input = QtWidgets.QLineEdit(
+            "" if prefix_val is None else str(prefix_val)
+        )
+        self.prefix_input.setValidator(QtGui.QIntValidator())
+        self.prefix_input.setPlaceholderText(placeholder)
+        self.prefix_input.setStyleSheet(
+            f"""
             QLineEdit {{
                 background-color: {BACKGROUND_COLOR};
                 color: {TEXT_COLOR};
@@ -55,14 +55,34 @@ class HeaderDialog(QtWidgets.QDialog):
                 border-radius: 5px;
                 padding: 5px;
             }}
-        """)
+            """
+        )
+        self.prefix_input.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred
+        )
+        layout.addWidget(self.prefix_input)
+
+        self.label_input = QtWidgets.QLineEdit(label)
+        self.label_input.setPlaceholderText("Label")
+        self.label_input.setStyleSheet(
+            f"""
+            QLineEdit {{
+                background-color: {BACKGROUND_COLOR};
+                color: {TEXT_COLOR};
+                border: 1px solid {BORDER_COLOR};
+                border-radius: 5px;
+                padding: 5px;
+            }}
+            """
+        )
         layout.addWidget(self.label_input)
 
         btn_row = QtWidgets.QHBoxLayout()
         ok_btn = QtWidgets.QPushButton("OK")
         cancel_btn = QtWidgets.QPushButton("Cancel")
         for b in (ok_btn, cancel_btn):
-            b.setStyleSheet(f"""
+            b.setStyleSheet(
+                f"""
                 QPushButton {{
                     background-color: {BUTTON_COLOR};
                     color: black;
@@ -73,8 +93,11 @@ class HeaderDialog(QtWidgets.QDialog):
                 QPushButton:hover {{
                     background-color: #e0c58f;
                 }}
-            """)
-            b.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred)
+                """
+            )
+            b.setSizePolicy(
+                QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred
+            )
         ok_btn.clicked.connect(self.accept)
         cancel_btn.clicked.connect(self.reject)
         btn_row.addWidget(ok_btn)
@@ -83,7 +106,8 @@ class HeaderDialog(QtWidgets.QDialog):
 
         if show_delete:
             self.delete_button = QtWidgets.QPushButton("Delete")
-            self.delete_button.setStyleSheet(f"""
+            self.delete_button.setStyleSheet(
+                f"""
                 QPushButton {{
                     background-color: {DELETE_BUTTON_COLOR};
                     color: black;
@@ -94,28 +118,27 @@ class HeaderDialog(QtWidgets.QDialog):
                 QPushButton:hover {{
                     background-color: #ff8ba7;
                 }}
-            """)
+                """
+            )
             self.delete_button.clicked.connect(self._on_delete)
-            self.delete_button.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred)
+            self.delete_button.setSizePolicy(
+                QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred
+            )
             layout.addWidget(self.delete_button)
 
-        self.setStyleSheet(f"""
+        self.setStyleSheet(
+            f"""
             QDialog {{
                 background-color: {BACKGROUND_COLOR};
             }}
             QLabel {{
                 color: {TEXT_COLOR};
             }}
-        """)
-        if level == 0:
-            self.jd_area_input.setFocus()
-            self.jd_area_input.selectAll()
-        elif level == 1:
-            self.jd_id_input.setFocus()
-            self.jd_id_input.selectAll()
-        else:
-            self.jd_ext_input.setFocus()
-            self.jd_ext_input.selectAll()
+            """
+        )
+
+        self.prefix_input.setFocus()
+        self.prefix_input.selectAll()
 
     def _on_delete(self):
         self.delete_pressed = True
@@ -123,10 +146,20 @@ class HeaderDialog(QtWidgets.QDialog):
 
     def get_values(self):
         try:
-            jd_area = int(self.jd_area_input.text()) if self.jd_area_input.text() else None
-            jd_id = int(self.jd_id_input.text()) if self.jd_id_input.text() else None
-            jd_ext = int(self.jd_ext_input.text()) if self.jd_ext_input.text() else None
+            prefix_val = (
+                int(self.prefix_input.text()) if self.prefix_input.text() else None
+            )
         except ValueError:
-            jd_area, jd_id, jd_ext = None, None, None
+            prefix_val = None
+
+        jd_area, jd_id, jd_ext = self.jd_area, self.jd_id, self.jd_ext
+
+        if self.level == 0:
+            jd_area = prefix_val
+        elif self.level == 1:
+            jd_id = prefix_val
+        else:
+            jd_ext = prefix_val
+
         return jd_area, jd_id, jd_ext, self.label_input.text()
 

--- a/jdbrowser/file_browser.py
+++ b/jdbrowser/file_browser.py
@@ -276,8 +276,14 @@ class FileBrowser(QtWidgets.QMainWindow):
             dialog = HeaderDialog(self.current_jd_area, self.current_jd_id, default_jd_ext, parent=self, level=self.current_level)
         if dialog.exec() == QtWidgets.QDialog.Accepted and not dialog.delete_pressed:
             jd_area, jd_id, jd_ext, label = dialog.get_values()
-            if jd_area is None:
+            if self.current_level == 0 and jd_area is None:
                 self._warn("Invalid Input", "jd_area must be an integer.")
+                return
+            if self.current_level == 1 and jd_id is None:
+                self._warn("Invalid Input", "jd_id must be an integer.")
+                return
+            if self.current_level == 2 and jd_ext is None:
+                self._warn("Invalid Input", "jd_ext must be an integer.")
                 return
             header_id = create_header(self.conn, jd_area, jd_id, jd_ext, label)
             if header_id:
@@ -622,10 +628,18 @@ class FileBrowser(QtWidgets.QMainWindow):
                 delete_header(self.conn, header_item.header_id)
             else:
                 jd_area, jd_id, jd_ext, label = dialog.get_values()
-                if jd_area is None:
+                if self.current_level == 0 and jd_area is None:
                     self._warn("Invalid Input", "jd_area must be an integer.")
                     return
-                if not update_header(self.conn, header_item.header_id, jd_area, jd_id, jd_ext, label):
+                if self.current_level == 1 and jd_id is None:
+                    self._warn("Invalid Input", "jd_id must be an integer.")
+                    return
+                if self.current_level == 2 and jd_ext is None:
+                    self._warn("Invalid Input", "jd_ext must be an integer.")
+                    return
+                if not update_header(
+                    self.conn, header_item.header_id, jd_area, jd_id, jd_ext, label
+                ):
                     self._warn("Invalid Input", "Header path conflicts or invalid.")
                     return
             rebuild_state_headers(self.conn)


### PR DESCRIPTION
## Summary
- Simplify header dialog to display one prefix field that adapts to jd_area, jd_id, or jd_ext.
- Ensure hidden jd parts are auto-filled based on current view when editing or creating headers.
- Validate appropriate prefix value when creating or editing headers.

## Testing
- `PYENV_VERSION=3.11.12 pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ee6fb6df4832cab23575321ec2f04