### PR TITLE
Add trailing placeholders for jd_ext sections

### DIFF
--- a/jdbrowser/file_browser.py
+++ b/jdbrowser/file_browser.py
@@ -888,6 +888,9 @@ class FileBrowser(QtWidgets.QMainWindow):
                     for i in range(end):
                         val = section_base + i
                         current_section.append(placeholder_item(val, section_index, i))
+                else:
+                    # Ensure a placeholder exists after the last actual item
+                    add_placeholders_until(next_index + 1)
                 add_section(current_section)
                 section_index += 1
                 current_section = None


### PR DESCRIPTION
## Summary
- ensure jd_ext sections always include a placeholder after the last real item so users have a drag target

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*
- `python3 -m pip install pytest --break-system-packages` *(fails: Could not find a version that satisfies the requirement pytest)*
- `python3 -m py_compile jdbrowser/file_browser.py`


------
https://chatgpt.com/codex/tasks/task_e_688ef359fa60832cb3758f7ea7c05075