### PR TITLE
Track parent UUID for tags and headers

### DIFF
--- a/jdbrowser/database.py
+++ b/jdbrowser/database.py
@@ -142,6 +142,20 @@ def setup_database(db_path):
             SELECT RAISE(ABORT, 'jd_ext requires jd_id');
         END;
     """)
+    # Ensure existing databases have the parent_uuid column
+    def ensure_parent_uuid(table_name):
+        cursor.execute(f"PRAGMA table_info({table_name})")
+        if 'parent_uuid' not in [row[1] for row in cursor.fetchall()]:
+            cursor.execute(f"ALTER TABLE {table_name} ADD COLUMN parent_uuid TEXT")
+
+    for table in (
+        "event_set_tag_path",
+        "state_tags",
+        "event_set_header_path",
+        "state_headers",
+    ):
+        ensure_parent_uuid(table)
+
     rebuild_state_tags(conn)
     rebuild_state_headers(conn)
     conn.commit()

--- a/jdbrowser/database.py
+++ b/jdbrowser/database.py
@@ -333,12 +333,12 @@ def create_header(conn, jd_area, jd_id, jd_ext, label):
     if jd_id is not None:
         if jd_ext is None:
             cursor.execute(
-                "SELECT header_id FROM state_headers WHERE jd_area = ? AND jd_id IS NULL AND jd_ext IS NULL",
+                "SELECT tag_id FROM state_tags WHERE jd_area = ? AND jd_id IS NULL AND jd_ext IS NULL",
                 (jd_area,),
             )
         else:
             cursor.execute(
-                "SELECT header_id FROM state_headers WHERE jd_area = ? AND jd_id = ? AND jd_ext IS NULL",
+                "SELECT tag_id FROM state_tags WHERE jd_area = ? AND jd_id = ? AND jd_ext IS NULL",
                 (jd_area, jd_id),
             )
         row = cursor.fetchone()
@@ -373,12 +373,12 @@ def update_header(conn, header_id, jd_area, jd_id, jd_ext, label):
     if jd_id is not None:
         if jd_ext is None:
             cursor.execute(
-                "SELECT header_id FROM state_headers WHERE jd_area = ? AND jd_id IS NULL AND jd_ext IS NULL",
+                "SELECT tag_id FROM state_tags WHERE jd_area = ? AND jd_id IS NULL AND jd_ext IS NULL",
                 (jd_area,),
             )
         else:
             cursor.execute(
-                "SELECT header_id FROM state_headers WHERE jd_area = ? AND jd_id = ? AND jd_ext IS NULL",
+                "SELECT tag_id FROM state_tags WHERE jd_area = ? AND jd_id = ? AND jd_ext IS NULL",
                 (jd_area, jd_id),
             )
         row = cursor.fetchone()


### PR DESCRIPTION
## Summary
- add parent_uuid to tag and header event/state tables
- compute and store parent_uuid when creating or moving tags and headers
- update UI drag/drop and edit flows to log parent relationships

## Testing
- `PYENV_VERSION=3.11.12 python -m py_compile jdbrowser/database.py jdbrowser/file_browser.py`
- `PYENV_VERSION=3.11.12 python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689388791844832cac63898926f9fd06