### PR TITLE
refactor: drop unused directory parameters

### DIFF
--- a/jdbrowser/file_item.py
+++ b/jdbrowser/file_item.py
@@ -2,7 +2,7 @@ from PySide6 import QtWidgets, QtGui, QtCore
 from .constants import *
 
 class FileItem(QtWidgets.QWidget):
-    def __init__(self, tag_id, name, jd_area, jd_id, jd_ext, icon_data, parent_path, page, section_idx, item_idx):
+    def __init__(self, tag_id, name, jd_area, jd_id, jd_ext, icon_data, page, section_idx, item_idx):
         super().__init__()
         self.tag_id = tag_id  # None for placeholder items
         self.name = name if name is not None else ""

--- a/jdbrowser/jd_area_page.py
+++ b/jdbrowser/jd_area_page.py
@@ -20,8 +20,7 @@ from .constants import *
 class JdAreaPage(QtWidgets.QMainWindow):
     def __init__(self):
         super().__init__()
-        self.directory = ""
-        self.setWindowTitle(f"File Browser - {self.directory}")
+        self.setWindowTitle("File Browser")
         self.current_jd_area = None
         self.current_jd_id = None
         self.cols = 10
@@ -670,7 +669,7 @@ class JdAreaPage(QtWidgets.QMainWindow):
 
         def placeholder_item(val, sec_idx, item_idx):
             pa, pi, pe = val, None, None
-            item = FileItem(None, None, pa, pi, pe, None, self.directory, self, sec_idx, item_idx)
+            item = FileItem(None, None, pa, pi, pe, None, self, sec_idx, item_idx)
             item.updateLabel(self.show_prefix)
             return item
 
@@ -706,7 +705,6 @@ class JdAreaPage(QtWidgets.QMainWindow):
                     jd_id,
                     jd_ext,
                     icon_data,
-                    self.directory,
                     self,
                     section_index,
                     index,

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -20,8 +20,7 @@ from .constants import *
 class JdExtPage(QtWidgets.QMainWindow):
     def __init__(self, parent_uuid, jd_area, jd_id):
         super().__init__()
-        self.directory = f"{jd_area}.{jd_id}" if jd_area is not None and jd_id is not None else ""
-        self.setWindowTitle(f"File Browser - {self.directory}")
+        self.setWindowTitle(f"File Browser - [{jd_area:02d}.{jd_id:02d}]")
         self.current_jd_area = jd_area
         self.current_jd_id = jd_id
         self.cols = 10
@@ -691,7 +690,7 @@ class JdExtPage(QtWidgets.QMainWindow):
         # Build sections and placeholders
         def placeholder_item(val, sec_idx, item_idx):
             pa, pi, pe = self.current_jd_area, self.current_jd_id, val
-            item = FileItem(None, None, pa, pi, pe, None, self.directory, self, sec_idx, item_idx)
+            item = FileItem(None, None, pa, pi, pe, None, self, sec_idx, item_idx)
             item.updateLabel(self.show_prefix)
             return item
 
@@ -791,7 +790,6 @@ class JdExtPage(QtWidgets.QMainWindow):
                     jd_id,
                     jd_ext,
                     icon_data,
-                    self.directory,
                     self,
                     section_index,
                     index,

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -23,8 +23,7 @@ class JdIdPage(QtWidgets.QMainWindow):
         self.parent_uuid = parent_uuid
         self.current_jd_area = jd_area
         self.current_jd_id = None
-        self.directory = str(jd_area) if jd_area is not None else ""
-        self.setWindowTitle(f"File Browser - {self.directory}")
+        self.setWindowTitle(f"File Browser - [{jd_area:02d}]")
         self.cols = 10
         self.sections = []
         self.section_paths = []  # Store (jd_area, jd_id, jd_ext) for each section
@@ -720,7 +719,7 @@ class JdIdPage(QtWidgets.QMainWindow):
                 pa, pi, pe = self.current_jd_area, val, None
             else:
                 pa, pi, pe = self.current_jd_area, self.current_jd_id, val
-            item = FileItem(None, None, pa, pi, pe, None, self.directory, self, sec_idx, item_idx)
+            item = FileItem(None, None, pa, pi, pe, None, self, sec_idx, item_idx)
             item.updateLabel(self.show_prefix)
             return item
 
@@ -759,7 +758,6 @@ class JdIdPage(QtWidgets.QMainWindow):
                         jd_id,
                         jd_ext,
                         icon_data,
-                        self.directory,
                         self,
                         section_index,
                         index,
@@ -891,7 +889,6 @@ class JdIdPage(QtWidgets.QMainWindow):
                         jd_id,
                         jd_ext,
                         icon_data,
-                        self.directory,
                         self,
                         section_index,
                         index,


### PR DESCRIPTION
## Summary
- remove unused parent_path from FileItem
- simplify window titles in page classes and inline directory strings

## Testing
- `PYENV_VERSION=system python3 -m py_compile jdbrowser/file_item.py jdbrowser/jd_area_page.py jdbrowser/jd_id_page.py jdbrowser/jd_ext_page.py`
- Failed: `/tmp/venv/bin/pip install pytest` (Could not find a version that satisfies the requirement pytest)


------
https://chatgpt.com/codex/tasks/task_e_68946e1acf44832c98643659e9064c56