### PR TITLE
Navigate to JdIdPage on Enter key

### DIFF
--- a/jdbrowser/jd_area_page.py
+++ b/jdbrowser/jd_area_page.py
@@ -1,6 +1,7 @@
 import os
 from collections import defaultdict
 from PySide6 import QtWidgets, QtGui, QtCore
+import jdbrowser
 from .dialogs import EditTagDialog, SimpleEditTagDialog, InputTagDialog, DeleteTagDialog
 from .dialogs.header_dialog import HeaderDialog
 from .file_item import FileItem
@@ -15,6 +16,7 @@ from .database import (
     delete_header,
     rebuild_state_headers,
 )
+from .jd_id_page import JdIdPage
 from .constants import *
 
 class JdAreaPage(QtWidgets.QMainWindow):
@@ -1088,7 +1090,23 @@ class JdAreaPage(QtWidgets.QMainWindow):
             self.updateSelection()
 
     def descend_level(self):
-        pass
+        if not self.sections:
+            return
+        if not (0 <= self.sec_idx < len(self.sections)):
+            return
+        sec = self.sections[self.sec_idx]
+        if not (0 <= self.idx_in_sec < len(sec)):
+            return
+        current_item = sec[self.idx_in_sec]
+        # Only descend if the current item represents a real tag (no placeholders)
+        if not current_item.tag_id:
+            return
+
+        # Instantiate the next level page and replace the current one
+        new_page = JdIdPage(parent_uuid=current_item.tag_id, jd_area=current_item.jd_area)
+        jdbrowser.current_page = new_page
+        new_page.show()
+        self.close()
 
     def updateSelection(self):
         if self.sections and 0 <= self.sec_idx < len(self.sections) and 0 <= self.idx_in_sec < len(self.sections[self.sec_idx]):


### PR DESCRIPTION
## Summary
- Replace area page with ID page when pressing Enter on an item
- Pass selected `jd_area` to the new `JdIdPage`

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689472384294832c81d6f07bdbcb285f