### PR TITLE
Use parent_uuid for item retrieval in JdIdPage

### DIFF
--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -642,14 +642,14 @@ class JdIdPage(QtWidgets.QMainWindow):
         cursor = self.conn.cursor()
         cursor.execute(
             "SELECT header_id, jd_area, jd_id, jd_ext, label FROM state_headers "
-            "WHERE jd_area = ? AND jd_id IS NOT NULL AND jd_ext IS NULL ORDER BY jd_id",
-            (self.current_jd_area,),
+            "WHERE parent_uuid IS ? ORDER BY jd_id",
+            (self.parent_uuid,),
         )
         headers = cursor.fetchall()
         cursor.execute(
             "SELECT tag_id, jd_area, jd_id, jd_ext, label FROM state_tags "
-            "WHERE jd_area = ? AND jd_id IS NOT NULL AND jd_ext IS NULL ORDER BY jd_id",
-            (self.current_jd_area,),
+            "WHERE parent_uuid IS ? ORDER BY jd_id",
+            (self.parent_uuid,),
         )
         tags = cursor.fetchall()
         cursor.execute("SELECT tag_id, icon FROM state_tag_icons")


### PR DESCRIPTION
## Summary
- Retrieve headers and tags in `JdIdPage` by `parent_uuid` rather than numeric path fields

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894781808f0832c81c610b05f729c51