### PR TITLE
Implement ascend level for extension page

### DIFF
--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -1,6 +1,7 @@
 import os
 from collections import defaultdict
 from PySide6 import QtWidgets, QtGui, QtCore
+import jdbrowser
 from .dialogs import EditTagDialog, SimpleEditTagDialog, InputTagDialog, DeleteTagDialog
 from .dialogs.header_dialog import HeaderDialog
 from .file_item import FileItem
@@ -361,7 +362,16 @@ class JdExtPage(QtWidgets.QMainWindow):
                 break
 
     def ascend_level(self):
-        pass
+        from .jd_id_page import JdIdPage
+
+        cursor = self.conn.cursor()
+        parent_uuid = self._get_parent_uuid(
+            cursor, self.current_jd_area, self.current_jd_id, None
+        )
+        new_page = JdIdPage(parent_uuid=parent_uuid, jd_area=self.current_jd_area)
+        jdbrowser.current_page = new_page
+        new_page.show()
+        self.close()
 
     def _edit_tag_label_with_icon(self):
         """Edit the current tag's label and thumbnail with a dialog showing the icon."""


### PR DESCRIPTION
## Summary
- allow JdExtPage to navigate back to its parent JdIdPage
- add jdbrowser import needed for navigation

## Testing
- `/usr/bin/python3 -m pytest` *(fails: No module named pytest)*
- `/usr/bin/pip3 install pytest --break-system-packages` *(fails: Could not find a version that satisfies the requirement pytest due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68947c81b838832ca83c4fa1ab491d19