### PR TITLE
Add parent_uuid indexes for faster tag and header queries

### DIFF
--- a/jdbrowser/database.py
+++ b/jdbrowser/database.py
@@ -141,6 +141,20 @@ def setup_database(db_path):
         BEGIN
             SELECT RAISE(ABORT, 'jd_ext requires jd_id');
         END;
+
+        -- Indexes to accelerate lookups by parent_uuid
+        CREATE INDEX IF NOT EXISTS idx_event_set_tag_path_parent_uuid
+            ON event_set_tag_path(parent_uuid);
+        CREATE INDEX IF NOT EXISTS idx_event_set_header_path_parent_uuid
+            ON event_set_header_path(parent_uuid);
+        CREATE INDEX IF NOT EXISTS idx_state_tags_parent_uuid_jd_id
+            ON state_tags(parent_uuid, jd_id);
+        CREATE INDEX IF NOT EXISTS idx_state_tags_parent_uuid_jd_ext
+            ON state_tags(parent_uuid, jd_ext);
+        CREATE INDEX IF NOT EXISTS idx_state_headers_parent_uuid_jd_id
+            ON state_headers(parent_uuid, jd_id);
+        CREATE INDEX IF NOT EXISTS idx_state_headers_parent_uuid_jd_ext
+            ON state_headers(parent_uuid, jd_ext);
     """)
     # Ensure existing databases have the parent_uuid column
     def ensure_parent_uuid(table_name):


### PR DESCRIPTION
## Summary
- index parent_uuid on event and state tables to optimize parent-child lookups

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*
- `python3 -m pip install pytest --break-system-packages` *(fails: Could not find a version that satisfies the requirement pytest)*
- `python3 - <<'PY'
from jdbrowser.database import setup_database
import os
path = 'temp.db'
if os.path.exists(path):
    os.remove(path)
conn = setup_database(path)
cur = conn.cursor()
for table in ['event_set_tag_path','event_set_header_path','state_tags','state_headers']:
    cur.execute(f"PRAGMA index_list({table})")
    print(table, cur.fetchall())
conn.close()
PY`

------
https://chatgpt.com/codex/tasks/task_e_689481f51b44832c8fd71268ab7513a6