### PR TITLE
Add jd_id manifested tables and event log tables

### DIFF
--- a/jdbrowser/database.py
+++ b/jdbrowser/database.py
@@ -31,7 +31,16 @@ def setup_database(db_path):
                     'create_jd_area_header',
                     'set_jd_area_header_order',
                     'set_jd_area_header_label',
-                    'delete_jd_area_header'
+                    'delete_jd_area_header',
+                    'create_jd_id_tag',
+                    'set_jd_id_tag_order',
+                    'set_jd_id_tag_label',
+                    'set_jd_id_tag_icon',
+                    'delete_jd_id_tag',
+                    'create_jd_id_header',
+                    'set_jd_id_header_order',
+                    'set_jd_id_header_label',
+                    'delete_jd_id_header'
                 )
             ),
             timestamp TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
@@ -161,6 +170,65 @@ def setup_database(db_path):
             FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
         );
 
+        CREATE TABLE IF NOT EXISTS event_create_jd_id_tag (
+            event_id INTEGER PRIMARY KEY,
+            tag_id TEXT NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS event_set_jd_id_tag_order (
+            event_id INTEGER PRIMARY KEY,
+            tag_id TEXT NOT NULL,
+            [order] INTEGER NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS event_set_jd_id_tag_label (
+            event_id INTEGER PRIMARY KEY,
+            tag_id TEXT NOT NULL,
+            new_label TEXT NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS event_set_jd_id_tag_icon (
+            event_id INTEGER PRIMARY KEY,
+            tag_id TEXT NOT NULL,
+            icon BLOB,
+            FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS event_delete_jd_id_tag (
+            event_id INTEGER PRIMARY KEY,
+            tag_id TEXT NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS event_create_jd_id_header (
+            event_id INTEGER PRIMARY KEY,
+            header_id TEXT NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS event_set_jd_id_header_order (
+            event_id INTEGER PRIMARY KEY,
+            header_id TEXT NOT NULL,
+            [order] INTEGER NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS event_set_jd_id_header_label (
+            event_id INTEGER PRIMARY KEY,
+            header_id TEXT NOT NULL,
+            new_label TEXT NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS event_delete_jd_id_header (
+            event_id INTEGER PRIMARY KEY,
+            header_id TEXT NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+        );
+
         CREATE TABLE IF NOT EXISTS state_headers (
             header_id TEXT PRIMARY KEY,
             parent_uuid TEXT,
@@ -172,6 +240,12 @@ def setup_database(db_path):
         );
 
         CREATE TABLE IF NOT EXISTS state_jd_area_headers (
+            header_id TEXT PRIMARY KEY,
+            [order] INTEGER NOT NULL UNIQUE,
+            label TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS state_jd_id_headers (
             header_id TEXT PRIMARY KEY,
             [order] INTEGER NOT NULL UNIQUE,
             label TEXT NOT NULL
@@ -195,6 +269,11 @@ def setup_database(db_path):
             icon BLOB
         );
 
+        CREATE TABLE IF NOT EXISTS state_jd_id_tag_icons (
+            tag_id TEXT PRIMARY KEY,
+            icon BLOB
+        );
+
         CREATE TABLE IF NOT EXISTS state_tags (
             tag_id TEXT PRIMARY KEY,
             parent_uuid TEXT,
@@ -206,6 +285,12 @@ def setup_database(db_path):
         );
 
         CREATE TABLE IF NOT EXISTS state_jd_area_tags (
+            tag_id TEXT PRIMARY KEY,
+            [order] INTEGER NOT NULL UNIQUE,
+            label TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS state_jd_id_tags (
             tag_id TEXT PRIMARY KEY,
             [order] INTEGER NOT NULL UNIQUE,
             label TEXT NOT NULL
@@ -259,6 +344,8 @@ def setup_database(db_path):
     rebuild_state_headers(conn)
     rebuild_state_jd_area_tags(conn)
     rebuild_state_jd_area_headers(conn)
+    rebuild_state_jd_id_tags(conn)
+    rebuild_state_jd_id_headers(conn)
     conn.commit()
     return conn
 
@@ -461,6 +548,100 @@ def rebuild_state_jd_area_headers(conn):
     """)
     conn.commit()
 
+def rebuild_state_jd_id_tags(conn):
+    """Rebuild the state_jd_id_tags table from the event log."""
+    cursor = conn.cursor()
+    cursor.executescript("""
+        DELETE FROM state_jd_id_tags;
+
+        INSERT INTO state_jd_id_tags (tag_id, [order], label)
+        SELECT
+            o.tag_id,
+            o.[order],
+            l.new_label
+        FROM (
+            SELECT
+                o.tag_id,
+                o.[order],
+                o.event_id
+            FROM event_set_jd_id_tag_order o
+            JOIN (
+                SELECT tag_id, MAX(event_id) AS max_event
+                FROM event_set_jd_id_tag_order
+                GROUP BY tag_id
+            ) latest_order ON o.tag_id = latest_order.tag_id AND o.event_id = latest_order.max_event
+        ) o
+        JOIN (
+            SELECT
+                l.tag_id,
+                l.new_label,
+                l.event_id
+            FROM event_set_jd_id_tag_label l
+            JOIN (
+                SELECT tag_id, MAX(event_id) AS max_event
+                FROM event_set_jd_id_tag_label
+                GROUP BY tag_id
+            ) latest_label ON l.tag_id = latest_label.tag_id AND l.event_id = latest_label.max_event
+        ) l ON o.tag_id = l.tag_id
+        WHERE o.tag_id NOT IN (SELECT tag_id FROM event_delete_jd_id_tag);
+    """)
+
+    cursor.executescript("""
+        DELETE FROM state_jd_id_tag_icons;
+
+        INSERT INTO state_jd_id_tag_icons (tag_id, icon)
+        SELECT
+            i.tag_id,
+            i.icon
+        FROM event_set_jd_id_tag_icon i
+        JOIN (
+            SELECT tag_id, MAX(event_id) AS max_event
+            FROM event_set_jd_id_tag_icon
+            GROUP BY tag_id
+        ) latest ON i.tag_id = latest.tag_id AND i.event_id = latest.max_event
+        WHERE i.tag_id NOT IN (SELECT tag_id FROM event_delete_jd_id_tag);
+    """)
+    conn.commit()
+
+def rebuild_state_jd_id_headers(conn):
+    """Rebuild the state_jd_id_headers table from the event log."""
+    cursor = conn.cursor()
+    cursor.executescript("""
+        DELETE FROM state_jd_id_headers;
+
+        INSERT INTO state_jd_id_headers (header_id, [order], label)
+        SELECT
+            o.header_id,
+            o.[order],
+            l.new_label
+        FROM (
+            SELECT
+                o.header_id,
+                o.[order],
+                o.event_id
+            FROM event_set_jd_id_header_order o
+            JOIN (
+                SELECT header_id, MAX(event_id) AS max_event
+                FROM event_set_jd_id_header_order
+                GROUP BY header_id
+            ) latest_order ON o.header_id = latest_order.header_id AND o.event_id = latest_order.max_event
+        ) o
+        JOIN (
+            SELECT
+                l.header_id,
+                l.new_label,
+                l.event_id
+            FROM event_set_jd_id_header_label l
+            JOIN (
+                SELECT header_id, MAX(event_id) AS max_event
+                FROM event_set_jd_id_header_label
+                GROUP BY header_id
+            ) latest_label ON l.header_id = latest_label.header_id AND l.event_id = latest_label.max_event
+        ) l ON o.header_id = l.header_id
+        WHERE o.header_id NOT IN (SELECT header_id FROM event_delete_jd_id_header);
+    """)
+    conn.commit()
+
 def create_jd_area_tag(conn, order, label):
     """Create a new jd_area tag and return its tag_id, or None if order conflict."""
     cursor = conn.cursor()
@@ -559,6 +740,108 @@ def delete_jd_area_tag(conn, tag_id):
     event_id = cursor.lastrowid
     cursor.execute(
         "INSERT INTO event_delete_jd_area_tag (event_id, tag_id) VALUES (?, ?)",
+        (event_id, tag_id),
+    )
+    conn.commit()
+
+def create_jd_id_tag(conn, order, label):
+    """Create a new jd_id tag and return its tag_id, or None if order conflict."""
+    cursor = conn.cursor()
+    cursor.execute('SELECT tag_id FROM state_jd_id_tags WHERE [order] = ?', (order,))
+    if cursor.fetchone():
+        return None
+    tag_id = str(uuid.uuid4())
+    cursor.execute("INSERT INTO events (event_type) VALUES ('create_jd_id_tag')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO event_create_jd_id_tag (event_id, tag_id) VALUES (?, ?)",
+        (event_id, tag_id),
+    )
+    cursor.execute("INSERT INTO events (event_type) VALUES ('set_jd_id_tag_order')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        'INSERT INTO event_set_jd_id_tag_order (event_id, tag_id, [order]) VALUES (?, ?, ?)',
+        (event_id, tag_id, order),
+    )
+    cursor.execute("INSERT INTO events (event_type) VALUES ('set_jd_id_tag_label')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO event_set_jd_id_tag_label (event_id, tag_id, new_label) VALUES (?, ?, ?)",
+        (event_id, tag_id, label),
+    )
+    conn.commit()
+    return tag_id
+
+def create_jd_id_header(conn, order, label):
+    """Create a new jd_id header and return its header_id, or None on conflict."""
+    cursor = conn.cursor()
+    cursor.execute('SELECT header_id FROM state_jd_id_headers WHERE [order] = ?', (order,))
+    if cursor.fetchone():
+        return None
+    header_id = str(uuid.uuid4())
+    cursor.execute("INSERT INTO events (event_type) VALUES ('create_jd_id_header')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO event_create_jd_id_header (event_id, header_id) VALUES (?, ?)",
+        (event_id, header_id),
+    )
+    cursor.execute("INSERT INTO events (event_type) VALUES ('set_jd_id_header_order')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        'INSERT INTO event_set_jd_id_header_order (event_id, header_id, [order]) VALUES (?, ?, ?)',
+        (event_id, header_id, order),
+    )
+    cursor.execute("INSERT INTO events (event_type) VALUES ('set_jd_id_header_label')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO event_set_jd_id_header_label (event_id, header_id, new_label) VALUES (?, ?, ?)",
+        (event_id, header_id, label),
+    )
+    conn.commit()
+    return header_id
+
+def update_jd_id_header(conn, header_id, order, label):
+    """Update an existing jd_id header. Returns True on success."""
+    cursor = conn.cursor()
+    cursor.execute(
+        'SELECT header_id FROM state_jd_id_headers WHERE [order] = ? AND header_id != ?',
+        (order, header_id),
+    )
+    if cursor.fetchone():
+        return False
+    cursor.execute("INSERT INTO events (event_type) VALUES ('set_jd_id_header_order')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        'INSERT INTO event_set_jd_id_header_order (event_id, header_id, [order]) VALUES (?, ?, ?)',
+        (event_id, header_id, order),
+    )
+    cursor.execute("INSERT INTO events (event_type) VALUES ('set_jd_id_header_label')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO event_set_jd_id_header_label (event_id, header_id, new_label) VALUES (?, ?, ?)",
+        (event_id, header_id, label),
+    )
+    conn.commit()
+    return True
+
+def delete_jd_id_header(conn, header_id):
+    """Delete an existing jd_id header."""
+    cursor = conn.cursor()
+    cursor.execute("INSERT INTO events (event_type) VALUES ('delete_jd_id_header')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO event_delete_jd_id_header (event_id, header_id) VALUES (?, ?)",
+        (event_id, header_id),
+    )
+    conn.commit()
+
+def delete_jd_id_tag(conn, tag_id):
+    """Delete an existing jd_id tag."""
+    cursor = conn.cursor()
+    cursor.execute("INSERT INTO events (event_type) VALUES ('delete_jd_id_tag')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO event_delete_jd_id_tag (event_id, tag_id) VALUES (?, ?)",
         (event_id, tag_id),
     )
     conn.commit()


### PR DESCRIPTION
## Summary
- add jd_id tag and header event types and log tables
- track jd_id tag icons and labels in new state_jd_id_* manifested tables
- rebuild jd_id state tables and provide CRUD helpers

## Testing
- `venv/bin/python -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_6896b4b10f04832cb6ede2642f7f5da3