### PR TITLE
Add jd_ext tag and header state tables

### DIFF
--- a/jdbrowser/database.py
+++ b/jdbrowser/database.py
@@ -40,7 +40,16 @@ def setup_database(db_path):
                     'create_jd_id_header',
                     'set_jd_id_header_order',
                     'set_jd_id_header_label',
-                    'delete_jd_id_header'
+                    'delete_jd_id_header',
+                    'create_jd_ext_tag',
+                    'set_jd_ext_tag_order',
+                    'set_jd_ext_tag_label',
+                    'set_jd_ext_tag_icon',
+                    'delete_jd_ext_tag',
+                    'create_jd_ext_header',
+                    'set_jd_ext_header_order',
+                    'set_jd_ext_header_label',
+                    'delete_jd_ext_header'
                 )
             ),
             timestamp TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
@@ -229,6 +238,67 @@ def setup_database(db_path):
             FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
         );
 
+        CREATE TABLE IF NOT EXISTS event_create_jd_ext_tag (
+            event_id INTEGER PRIMARY KEY,
+            tag_id TEXT NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS event_set_jd_ext_tag_order (
+            event_id INTEGER PRIMARY KEY,
+            tag_id TEXT NOT NULL,
+            parent_uuid TEXT,
+            [order] INTEGER NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS event_set_jd_ext_tag_label (
+            event_id INTEGER PRIMARY KEY,
+            tag_id TEXT NOT NULL,
+            new_label TEXT NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS event_set_jd_ext_tag_icon (
+            event_id INTEGER PRIMARY KEY,
+            tag_id TEXT NOT NULL,
+            icon BLOB,
+            FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS event_delete_jd_ext_tag (
+            event_id INTEGER PRIMARY KEY,
+            tag_id TEXT NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS event_create_jd_ext_header (
+            event_id INTEGER PRIMARY KEY,
+            header_id TEXT NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS event_set_jd_ext_header_order (
+            event_id INTEGER PRIMARY KEY,
+            header_id TEXT NOT NULL,
+            parent_uuid TEXT,
+            [order] INTEGER NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS event_set_jd_ext_header_label (
+            event_id INTEGER PRIMARY KEY,
+            header_id TEXT NOT NULL,
+            new_label TEXT NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS event_delete_jd_ext_header (
+            event_id INTEGER PRIMARY KEY,
+            header_id TEXT NOT NULL,
+            FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE CASCADE
+        );
+
         CREATE TABLE IF NOT EXISTS state_headers (
             header_id TEXT PRIMARY KEY,
             parent_uuid TEXT,
@@ -249,6 +319,14 @@ def setup_database(db_path):
             header_id TEXT PRIMARY KEY,
             [order] INTEGER NOT NULL UNIQUE,
             label TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS state_jd_ext_headers (
+            header_id TEXT PRIMARY KEY,
+            parent_uuid TEXT,
+            [order] INTEGER NOT NULL,
+            label TEXT NOT NULL,
+            UNIQUE(parent_uuid, [order])
         );
 
         -- Trigger to prevent jd_ext without jd_id for headers
@@ -274,6 +352,11 @@ def setup_database(db_path):
             icon BLOB
         );
 
+        CREATE TABLE IF NOT EXISTS state_jd_ext_tag_icons (
+            tag_id TEXT PRIMARY KEY,
+            icon BLOB
+        );
+
         CREATE TABLE IF NOT EXISTS state_tags (
             tag_id TEXT PRIMARY KEY,
             parent_uuid TEXT,
@@ -294,6 +377,14 @@ def setup_database(db_path):
             tag_id TEXT PRIMARY KEY,
             [order] INTEGER NOT NULL UNIQUE,
             label TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS state_jd_ext_tags (
+            tag_id TEXT PRIMARY KEY,
+            parent_uuid TEXT,
+            [order] INTEGER NOT NULL,
+            label TEXT NOT NULL,
+            UNIQUE(parent_uuid, [order])
         );
 
         -- Trigger to prevent jd_id without jd_area
@@ -325,6 +416,14 @@ def setup_database(db_path):
             ON state_headers(parent_uuid, jd_id);
         CREATE INDEX IF NOT EXISTS idx_state_headers_parent_uuid_jd_ext
             ON state_headers(parent_uuid, jd_ext);
+        CREATE INDEX IF NOT EXISTS idx_event_set_jd_ext_tag_order_parent_uuid
+            ON event_set_jd_ext_tag_order(parent_uuid);
+        CREATE INDEX IF NOT EXISTS idx_event_set_jd_ext_header_order_parent_uuid
+            ON event_set_jd_ext_header_order(parent_uuid);
+        CREATE INDEX IF NOT EXISTS idx_state_jd_ext_tags_parent_uuid
+            ON state_jd_ext_tags(parent_uuid);
+        CREATE INDEX IF NOT EXISTS idx_state_jd_ext_headers_parent_uuid
+            ON state_jd_ext_headers(parent_uuid);
     """)
     # Ensure existing databases have the parent_uuid column
     def ensure_parent_uuid(table_name):
@@ -346,6 +445,8 @@ def setup_database(db_path):
     rebuild_state_jd_area_headers(conn)
     rebuild_state_jd_id_tags(conn)
     rebuild_state_jd_id_headers(conn)
+    rebuild_state_jd_ext_tags(conn)
+    rebuild_state_jd_ext_headers(conn)
     conn.commit()
     return conn
 
@@ -640,6 +741,212 @@ def rebuild_state_jd_id_headers(conn):
         ) l ON o.header_id = l.header_id
         WHERE o.header_id NOT IN (SELECT header_id FROM event_delete_jd_id_header);
     """)
+    conn.commit()
+
+def rebuild_state_jd_ext_tags(conn):
+    """Rebuild the state_jd_ext_tags table from the event log."""
+    cursor = conn.cursor()
+    cursor.executescript("""
+        DELETE FROM state_jd_ext_tags;
+
+        INSERT INTO state_jd_ext_tags (tag_id, parent_uuid, [order], label)
+        SELECT
+            o.tag_id,
+            o.parent_uuid,
+            o.[order],
+            l.new_label
+        FROM (
+            SELECT
+                o.tag_id,
+                o.parent_uuid,
+                o.[order],
+                o.event_id
+            FROM event_set_jd_ext_tag_order o
+            JOIN (
+                SELECT tag_id, MAX(event_id) AS max_event
+                FROM event_set_jd_ext_tag_order
+                GROUP BY tag_id
+            ) latest_order ON o.tag_id = latest_order.tag_id AND o.event_id = latest_order.max_event
+        ) o
+        JOIN (
+            SELECT
+                l.tag_id,
+                l.new_label,
+                l.event_id
+            FROM event_set_jd_ext_tag_label l
+            JOIN (
+                SELECT tag_id, MAX(event_id) AS max_event
+                FROM event_set_jd_ext_tag_label
+                GROUP BY tag_id
+            ) latest_label ON l.tag_id = latest_label.tag_id AND l.event_id = latest_label.max_event
+        ) l ON o.tag_id = l.tag_id
+        WHERE o.tag_id NOT IN (SELECT tag_id FROM event_delete_jd_ext_tag);
+    """)
+
+    cursor.executescript("""
+        DELETE FROM state_jd_ext_tag_icons;
+
+        INSERT INTO state_jd_ext_tag_icons (tag_id, icon)
+        SELECT
+            i.tag_id,
+            i.icon
+        FROM event_set_jd_ext_tag_icon i
+        JOIN (
+            SELECT tag_id, MAX(event_id) AS max_event
+            FROM event_set_jd_ext_tag_icon
+            GROUP BY tag_id
+        ) latest ON i.tag_id = latest.tag_id AND i.event_id = latest.max_event
+        WHERE i.tag_id NOT IN (SELECT tag_id FROM event_delete_jd_ext_tag);
+    """)
+    conn.commit()
+
+def rebuild_state_jd_ext_headers(conn):
+    """Rebuild the state_jd_ext_headers table from the event log."""
+    cursor = conn.cursor()
+    cursor.executescript("""
+        DELETE FROM state_jd_ext_headers;
+
+        INSERT INTO state_jd_ext_headers (header_id, parent_uuid, [order], label)
+        SELECT
+            o.header_id,
+            o.parent_uuid,
+            o.[order],
+            l.new_label
+        FROM (
+            SELECT
+                o.header_id,
+                o.parent_uuid,
+                o.[order],
+                o.event_id
+            FROM event_set_jd_ext_header_order o
+            JOIN (
+                SELECT header_id, MAX(event_id) AS max_event
+                FROM event_set_jd_ext_header_order
+                GROUP BY header_id
+            ) latest_order ON o.header_id = latest_order.header_id AND o.event_id = latest_order.max_event
+        ) o
+        JOIN (
+            SELECT
+                l.header_id,
+                l.new_label,
+                l.event_id
+            FROM event_set_jd_ext_header_label l
+            JOIN (
+                SELECT header_id, MAX(event_id) AS max_event
+                FROM event_set_jd_ext_header_label
+                GROUP BY header_id
+            ) latest_label ON l.header_id = latest_label.header_id AND l.event_id = latest_label.max_event
+        ) l ON o.header_id = l.header_id
+        WHERE o.header_id NOT IN (SELECT header_id FROM event_delete_jd_ext_header);
+    """)
+    conn.commit()
+
+def create_jd_ext_tag(conn, parent_uuid, order, label):
+    """Create a new jd_ext tag and return its tag_id, or None on conflict."""
+    cursor = conn.cursor()
+    cursor.execute(
+        'SELECT tag_id FROM state_jd_ext_tags WHERE parent_uuid IS ? AND [order] = ?',
+        (parent_uuid, order),
+    )
+    if cursor.fetchone():
+        return None
+    tag_id = str(uuid.uuid4())
+    cursor.execute("INSERT INTO events (event_type) VALUES ('create_jd_ext_tag')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO event_create_jd_ext_tag (event_id, tag_id) VALUES (?, ?)",
+        (event_id, tag_id),
+    )
+    cursor.execute("INSERT INTO events (event_type) VALUES ('set_jd_ext_tag_order')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        'INSERT INTO event_set_jd_ext_tag_order (event_id, tag_id, parent_uuid, [order]) VALUES (?, ?, ?, ?)',
+        (event_id, tag_id, parent_uuid, order),
+    )
+    cursor.execute("INSERT INTO events (event_type) VALUES ('set_jd_ext_tag_label')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO event_set_jd_ext_tag_label (event_id, tag_id, new_label) VALUES (?, ?, ?)",
+        (event_id, tag_id, label),
+    )
+    conn.commit()
+    return tag_id
+
+def delete_jd_ext_tag(conn, tag_id):
+    """Delete an existing jd_ext tag."""
+    cursor = conn.cursor()
+    cursor.execute("INSERT INTO events (event_type) VALUES ('delete_jd_ext_tag')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO event_delete_jd_ext_tag (event_id, tag_id) VALUES (?, ?)",
+        (event_id, tag_id),
+    )
+    conn.commit()
+
+def create_jd_ext_header(conn, parent_uuid, order, label):
+    """Create a new jd_ext header and return its header_id, or None on conflict."""
+    cursor = conn.cursor()
+    cursor.execute(
+        'SELECT header_id FROM state_jd_ext_headers WHERE parent_uuid IS ? AND [order] = ?',
+        (parent_uuid, order),
+    )
+    if cursor.fetchone():
+        return None
+    header_id = str(uuid.uuid4())
+    cursor.execute("INSERT INTO events (event_type) VALUES ('create_jd_ext_header')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO event_create_jd_ext_header (event_id, header_id) VALUES (?, ?)",
+        (event_id, header_id),
+    )
+    cursor.execute("INSERT INTO events (event_type) VALUES ('set_jd_ext_header_order')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        'INSERT INTO event_set_jd_ext_header_order (event_id, header_id, parent_uuid, [order]) VALUES (?, ?, ?, ?)',
+        (event_id, header_id, parent_uuid, order),
+    )
+    cursor.execute("INSERT INTO events (event_type) VALUES ('set_jd_ext_header_label')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO event_set_jd_ext_header_label (event_id, header_id, new_label) VALUES (?, ?, ?)",
+        (event_id, header_id, label),
+    )
+    conn.commit()
+    return header_id
+
+def update_jd_ext_header(conn, header_id, parent_uuid, order, label):
+    """Update an existing jd_ext header. Returns True on success."""
+    cursor = conn.cursor()
+    cursor.execute(
+        'SELECT header_id FROM state_jd_ext_headers WHERE parent_uuid IS ? AND [order] = ? AND header_id != ?',
+        (parent_uuid, order, header_id),
+    )
+    if cursor.fetchone():
+        return False
+    cursor.execute("INSERT INTO events (event_type) VALUES ('set_jd_ext_header_order')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        'INSERT INTO event_set_jd_ext_header_order (event_id, header_id, parent_uuid, [order]) VALUES (?, ?, ?, ?)',
+        (event_id, header_id, parent_uuid, order),
+    )
+    cursor.execute("INSERT INTO events (event_type) VALUES ('set_jd_ext_header_label')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO event_set_jd_ext_header_label (event_id, header_id, new_label) VALUES (?, ?, ?)",
+        (event_id, header_id, label),
+    )
+    conn.commit()
+    return True
+
+def delete_jd_ext_header(conn, header_id):
+    """Delete an existing jd_ext header."""
+    cursor = conn.cursor()
+    cursor.execute("INSERT INTO events (event_type) VALUES ('delete_jd_ext_header')")
+    event_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO event_delete_jd_ext_header (event_id, header_id) VALUES (?, ?)",
+        (event_id, header_id),
+    )
     conn.commit()
 
 def create_jd_area_tag(conn, order, label):


### PR DESCRIPTION
## Summary
- Track jd_ext tag events with parent-linked order fields and icons
- Maintain jd_ext header state with parent uuid and ordering
- Provide rebuild and CRUD helpers for jd_ext tags and headers

## Testing
- `python3 -m py_compile jdbrowser/database.py`
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_6896b702ef48832c8b5948819f613799