### PR TITLE
Refactor InputTagDialog to single order field

### DIFF
--- a/jdbrowser/dialogs/input_tag_dialog.py
+++ b/jdbrowser/dialogs/input_tag_dialog.py
@@ -3,7 +3,7 @@ from ..constants import *
 
 
 class InputTagDialog(QtWidgets.QDialog):
-    def __init__(self, default_jd_area=None, default_jd_id=None, default_jd_ext=None, default_label="", level=0, parent=None):
+    def __init__(self, default_order=None, default_label="", parent=None):
         super().__init__(parent)
         self.setWindowTitle("Create Tag")
         self.setFixedWidth(300)
@@ -11,15 +11,10 @@ class InputTagDialog(QtWidgets.QDialog):
         layout.setSpacing(10)
         layout.setContentsMargins(10, 10, 10, 10)
 
-        self.level = level
-        self.fixed_jd_area = default_jd_area if level >= 1 else None
-        self.fixed_jd_id = default_jd_id if level >= 2 else None
-        default_prefix = [default_jd_area, default_jd_id, default_jd_ext][level]
-        placeholder = ["jd_area", "jd_id", "jd_ext"][level]
-        self.prefix_input = QtWidgets.QLineEdit("" if default_prefix is None else str(default_prefix))
-        self.prefix_input.setPlaceholderText(placeholder)
-        self.prefix_input.setValidator(QtGui.QIntValidator())
-        self.prefix_input.setStyleSheet(f'''
+        self.order_input = QtWidgets.QLineEdit("" if default_order is None else str(default_order))
+        self.order_input.setPlaceholderText("Order")
+        self.order_input.setValidator(QtGui.QIntValidator())
+        self.order_input.setStyleSheet(f'''
             QLineEdit {{
                 background-color: {BACKGROUND_COLOR};
                 color: {TEXT_COLOR};
@@ -28,8 +23,8 @@ class InputTagDialog(QtWidgets.QDialog):
                 padding: 5px;
             }}
         ''')
-        self.prefix_input.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred)
-        layout.addWidget(self.prefix_input)
+        self.order_input.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred)
+        layout.addWidget(self.order_input)
 
         self.label_input = QtWidgets.QLineEdit(default_label)
         self.label_input.setPlaceholderText("Label")
@@ -75,14 +70,8 @@ class InputTagDialog(QtWidgets.QDialog):
 
     def get_values(self):
         try:
-            prefix = int(self.prefix_input.text()) if self.prefix_input.text() else None
+            order = int(self.order_input.text()) if self.order_input.text() else None
         except ValueError:
-            prefix = None
-        if self.level == 0:
-            jd_area, jd_id, jd_ext = prefix, None, None
-        elif self.level == 1:
-            jd_area, jd_id, jd_ext = self.fixed_jd_area, prefix, None
-        else:
-            jd_area, jd_id, jd_ext = self.fixed_jd_area, self.fixed_jd_id, prefix
-        return jd_area, jd_id, jd_ext, self.label_input.text()
+            order = None
+        return order, self.label_input.text()
 

--- a/jdbrowser/jd_area_page.py
+++ b/jdbrowser/jd_area_page.py
@@ -308,13 +308,12 @@ class JdAreaPage(QtWidgets.QMainWindow):
         )
         max_order = cursor.fetchone()[0]
         default_order = max_order + 1 if max_order is not None else base
-        dialog = InputTagDialog(default_order, None, None, default_label, level=0, parent=self)
+        dialog = InputTagDialog(default_order, default_label, parent=self)
         while True:
             if dialog.exec() == QtWidgets.QDialog.Accepted:
-                jd_area, jd_id, jd_ext, label = dialog.get_values()
-                order = jd_area
+                order, label = dialog.get_values()
                 if order is None:
-                    self._warn("Invalid Input", "jd_area must be an integer.")
+                    self._warn("Invalid Input", "Order must be an integer.")
                     continue
                 new_tag_id = create_jd_area_tag(self.conn, order, label)
                 if new_tag_id:
@@ -324,7 +323,7 @@ class JdAreaPage(QtWidgets.QMainWindow):
                 else:
                     self._warn(
                         "Constraint Violation",
-                        f"jd_area={order} is already in use.",
+                        f"Order {order} is already in use.",
                     )
             else:
                 break
@@ -339,13 +338,12 @@ class JdAreaPage(QtWidgets.QMainWindow):
         current_item = self.sections[self.sec_idx][self.idx_in_sec]
         if not current_item.tag_id:
             default_label = "NewTag"
-            dialog = InputTagDialog(current_item.jd_area, None, None, default_label, level=0, parent=self)
+            dialog = InputTagDialog(current_item.jd_area, default_label, parent=self)
             while True:
                 if dialog.exec() == QtWidgets.QDialog.Accepted:
-                    jd_area, jd_id, jd_ext, label = dialog.get_values()
-                    order = jd_area
+                    order, label = dialog.get_values()
                     if order is None:
-                        self._warn("Invalid Input", "jd_area must be an integer.")
+                        self._warn("Invalid Input", "Order must be an integer.")
                         continue
                     new_tag_id = create_jd_area_tag(self.conn, order, label)
                     if new_tag_id:
@@ -355,7 +353,7 @@ class JdAreaPage(QtWidgets.QMainWindow):
                     else:
                         self._warn(
                             "Constraint Violation",
-                            f"jd_area={order} is already in use.",
+                            f"Order {order} is already in use.",
                         )
                 else:
                     break

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -316,18 +316,15 @@ class JdExtPage(QtWidgets.QMainWindow):
         max_order = cursor.fetchone()[0]
         default_order = max_order + 1 if max_order is not None else base
         dialog = InputTagDialog(
-            self.current_jd_area,
-            self.current_jd_id,
             default_order,
             default_label,
-            level=2,
             parent=self,
         )
         while True:
             if dialog.exec() == QtWidgets.QDialog.Accepted:
-                _, _, order, label = dialog.get_values()
+                order, label = dialog.get_values()
                 if order is None:
-                    self._warn("Invalid Input", "jd_ext must be an integer.")
+                    self._warn("Invalid Input", "Order must be an integer.")
                     continue
                 new_tag_id = create_jd_ext_tag(self.conn, self.parent_uuid, order, label)
                 if new_tag_id:
@@ -358,18 +355,15 @@ class JdExtPage(QtWidgets.QMainWindow):
         if not current_item.tag_id:
             default_label = "NewTag"
             dialog = InputTagDialog(
-                current_item.jd_area,
-                current_item.jd_id,
                 current_item.jd_ext,
                 default_label,
-                level=2,
                 parent=self,
             )
             while True:
                 if dialog.exec() == QtWidgets.QDialog.Accepted:
-                    _, _, order, label = dialog.get_values()
+                    order, label = dialog.get_values()
                     if order is None:
-                        self._warn("Invalid Input", "jd_ext must be an integer.")
+                        self._warn("Invalid Input", "Order must be an integer.")
                         continue
                     new_tag_id = create_jd_ext_tag(self.conn, self.parent_uuid, order, label)
                     if new_tag_id:

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -314,12 +314,12 @@ class JdIdPage(QtWidgets.QMainWindow):
         )
         max_order = cursor.fetchone()[0]
         default_order = max_order + 1 if max_order is not None else base
-        dialog = InputTagDialog(self.current_jd_area, default_order, None, default_label, level=1, parent=self)
+        dialog = InputTagDialog(default_order, default_label, parent=self)
         while True:
             if dialog.exec() == QtWidgets.QDialog.Accepted:
-                _, order, _, label = dialog.get_values()
+                order, label = dialog.get_values()
                 if order is None:
-                    self._warn("Invalid Input", "jd_id must be an integer.")
+                    self._warn("Invalid Input", "Order must be an integer.")
                     continue
                 new_tag_id = create_jd_id_tag(self.conn, self.parent_uuid, order, label)
                 if new_tag_id:
@@ -349,18 +349,15 @@ class JdIdPage(QtWidgets.QMainWindow):
         if not current_item.tag_id:
             default_label = "NewTag"
             dialog = InputTagDialog(
-                current_item.jd_area,
                 current_item.jd_id,
-                current_item.jd_ext,
                 default_label,
-                level=1,
                 parent=self,
             )
             while True:
                 if dialog.exec() == QtWidgets.QDialog.Accepted:
-                    _, order, _, label = dialog.get_values()
+                    order, label = dialog.get_values()
                     if order is None:
-                        self._warn("Invalid Input", "jd_id must be an integer.")
+                        self._warn("Invalid Input", "Order must be an integer.")
                         continue
                     new_tag_id = create_jd_id_tag(self.conn, self.parent_uuid, order, label)
                     if new_tag_id:


### PR DESCRIPTION
## Summary
- simplify InputTagDialog to use a single numeric order field and drop level parameter
- update jd_area_page, jd_id_page, and jd_ext_page to use the revised dialog

## Testing
- `python3 -m py_compile jdbrowser/dialogs/input_tag_dialog.py jdbrowser/jd_area_page.py jdbrowser/jd_id_page.py jdbrowser/jd_ext_page.py`
- `python3 -m pytest` *(fails: No module named pytest)*
- `python3 -m pip install pytest` *(fails: externally-managed-environment)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6897166f00fc832c8487b9d3548b0f4d