### PR TITLE
Ensure parent_uuid added for ext tables

### DIFF
--- a/jdbrowser/database.py
+++ b/jdbrowser/database.py
@@ -314,6 +314,10 @@ def setup_database(db_path):
         "state_jd_id_tags",
         "event_set_jd_id_header_order",
         "state_jd_id_headers",
+        "event_set_jd_ext_tag_order",
+        "state_jd_ext_tags",
+        "event_set_jd_ext_header_order",
+        "state_jd_ext_headers",
     ):
         ensure_parent_uuid(table)
 


### PR DESCRIPTION
## Summary
- run `ensure_parent_uuid` for ext tag/header tables during setup/migration

## Testing
- `python3 - <<'PY' ...` (verify parent_uuid column present in ext tables)
- `python3 -m pytest` *(fails: No module named pytest)*
- `pip install pytest` *(fails: externally managed environment)*

------
https://chatgpt.com/codex/tasks/task_e_689722e9f1a8832cb41dd48abe0b3287