### PR TITLE
Fix section navigation across headers

### DIFF
--- a/jdbrowser/jd_area_page.py
+++ b/jdbrowser/jd_area_page.py
@@ -31,6 +31,7 @@ class JdAreaPage(QtWidgets.QMainWindow):
         self.sections = []
         self.section_paths = []  # Store (jd_area, jd_id, jd_ext) for each section
         self.section_filenames = []  # Store .2do filenames for sorting
+        self.header_orders = []
         self.sec_idx = 0
         self.idx_in_sec = 0
         self.desired_col = 0
@@ -560,6 +561,7 @@ class JdAreaPage(QtWidgets.QMainWindow):
             "SELECT header_id, [order], label FROM state_jd_area_headers ORDER BY [order]"
         )
         headers = cursor.fetchall()
+        self.header_orders = sorted([order for _, order, _ in headers])
         cursor.execute(
             "SELECT tag_id, [order], label FROM state_jd_area_tags ORDER BY [order]"
         )
@@ -928,24 +930,53 @@ class JdAreaPage(QtWidgets.QMainWindow):
 
     def moveToSectionStart(self):
         if not self.in_search_mode and self.sections:
-            if self.idx_in_sec == 0 and self.sec_idx > 0:
-                self.sec_idx -= 1
-                self.idx_in_sec = 0
-            else:
-                self.idx_in_sec = 0
-            self.desired_col = 0
+            base = self.section_paths[self.sec_idx][0]
+            current_order = base + self.idx_in_sec
+            target_order = 0
+            for h in self.header_orders:
+                if h <= current_order:
+                    target_order = h
+                else:
+                    break
+            target_base = (target_order // 10) * 10
+            sec_idx = next(
+                (i for i, p in enumerate(self.section_paths) if p[0] == target_base),
+                0,
+            )
+            self.sec_idx = sec_idx
+            self.idx_in_sec = min(
+                target_order - target_base, len(self.sections[sec_idx]) - 1
+            )
+            self.desired_col = self.idx_in_sec % self.cols
             self.updateSelection()
 
     def moveToSectionEnd(self):
         if not self.in_search_mode and self.sections:
-            sec = self.sections[self.sec_idx]
-            last_idx = len(sec) - 1
-            if self.idx_in_sec == last_idx and self.sec_idx < len(self.sections) - 1:
-                self.sec_idx += 1
-                sec = self.sections[self.sec_idx]
-                self.idx_in_sec = len(sec) - 1
+            base = self.section_paths[self.sec_idx][0]
+            current_order = base + self.idx_in_sec
+            next_header = None
+            for h in self.header_orders:
+                if h > current_order:
+                    next_header = h
+                    break
+            if next_header is None:
+                self.sec_idx = len(self.sections) - 1
+                self.idx_in_sec = len(self.sections[self.sec_idx]) - 1
             else:
-                self.idx_in_sec = last_idx
+                target_order = next_header - 1
+                target_base = (target_order // 10) * 10
+                sec_idx = next(
+                    (
+                        i
+                        for i, p in enumerate(self.section_paths)
+                        if p[0] == target_base
+                    ),
+                    len(self.sections) - 1,
+                )
+                self.sec_idx = sec_idx
+                self.idx_in_sec = min(
+                    target_order - target_base, len(self.sections[sec_idx]) - 1
+                )
             self.desired_col = self.idx_in_sec % self.cols
             self.updateSelection()
 

--- a/jdbrowser/jd_area_page.py
+++ b/jdbrowser/jd_area_page.py
@@ -933,20 +933,30 @@ class JdAreaPage(QtWidgets.QMainWindow):
             base = self.section_paths[self.sec_idx][0]
             current_order = base + self.idx_in_sec
             target_order = 0
-            for h in self.header_orders:
+            header_index = 0
+            for i, h in enumerate(self.header_orders):
                 if h <= current_order:
                     target_order = h
+                    header_index = i
                 else:
                     break
-            target_base = (target_order // 10) * 10
+            start_base = (target_order // 10) * 10
+            start_idx = target_order - start_base
+            # If we're already at the start of this section and there is a previous
+            # header, move to the start of the previous section instead.
+            if (
+                self.idx_in_sec == start_idx
+                and header_index > 0
+            ):
+                target_order = self.header_orders[header_index - 1]
+                start_base = (target_order // 10) * 10
+                start_idx = target_order - start_base
             sec_idx = next(
-                (i for i, p in enumerate(self.section_paths) if p[0] == target_base),
-                0,
+                (i for i, p in enumerate(self.section_paths) if p[0] == start_base),
+                self.sec_idx,
             )
             self.sec_idx = sec_idx
-            self.idx_in_sec = min(
-                target_order - target_base, len(self.sections[sec_idx]) - 1
-            )
+            self.idx_in_sec = min(start_idx, len(self.sections[sec_idx]) - 1)
             self.desired_col = self.idx_in_sec % self.cols
             self.updateSelection()
 
@@ -954,29 +964,38 @@ class JdAreaPage(QtWidgets.QMainWindow):
         if not self.in_search_mode and self.sections:
             base = self.section_paths[self.sec_idx][0]
             current_order = base + self.idx_in_sec
-            next_header = None
-            for h in self.header_orders:
+            next_index = None
+            for i, h in enumerate(self.header_orders):
                 if h > current_order:
-                    next_header = h
+                    next_index = i
                     break
-            if next_header is None:
+            if next_index is None:
+                # No later header; jump to absolute last item
                 self.sec_idx = len(self.sections) - 1
                 self.idx_in_sec = len(self.sections[self.sec_idx]) - 1
             else:
-                target_order = next_header - 1
-                target_base = (target_order // 10) * 10
+                target_order = self.header_orders[next_index] - 1
+                end_base = (target_order // 10) * 10
+                end_idx = target_order - end_base
+                # If we're already at end of this section and there is another
+                # section after the next header, jump to its end instead.
+                if (
+                    self.idx_in_sec == end_idx
+                    and next_index + 1 < len(self.header_orders)
+                ):
+                    target_order = self.header_orders[next_index + 1] - 1
+                    end_base = (target_order // 10) * 10
+                    end_idx = target_order - end_base
                 sec_idx = next(
                     (
                         i
                         for i, p in enumerate(self.section_paths)
-                        if p[0] == target_base
+                        if p[0] == end_base
                     ),
                     len(self.sections) - 1,
                 )
                 self.sec_idx = sec_idx
-                self.idx_in_sec = min(
-                    target_order - target_base, len(self.sections[sec_idx]) - 1
-                )
+                self.idx_in_sec = min(end_idx, len(self.sections[sec_idx]) - 1)
             self.desired_col = self.idx_in_sec % self.cols
             self.updateSelection()
 

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -605,7 +605,7 @@ class JdExtPage(QtWidgets.QMainWindow):
             (self.parent_uuid,),
         )
         headers = cursor.fetchall()
-        self.header_orders = sorted([order for _, order, _ in headers])
+        self.header_orders = sorted({0, *(order for _, order, _ in headers)})
         cursor.execute(
             "SELECT tag_id, [order], label FROM state_jd_ext_tags WHERE parent_uuid IS ? ORDER BY [order]",
             (self.parent_uuid,),
@@ -1075,13 +1075,17 @@ class JdExtPage(QtWidgets.QMainWindow):
                 target_order = self.header_orders[next_index] - 1
                 end_base = (target_order // 10) * 10
                 end_idx = target_order - end_base
-                if (
-                    self.idx_in_sec == end_idx
-                    and next_index + 1 < len(self.header_orders)
-                ):
-                    target_order = self.header_orders[next_index + 1] - 1
-                    end_base = (target_order // 10) * 10
-                    end_idx = target_order - end_base
+                if self.idx_in_sec == end_idx:
+                    if next_index + 1 < len(self.header_orders):
+                        target_order = self.header_orders[next_index + 1] - 1
+                        end_base = (target_order // 10) * 10
+                        end_idx = target_order - end_base
+                    else:
+                        self.sec_idx = len(self.sections) - 1
+                        self.idx_in_sec = len(self.sections[self.sec_idx]) - 1
+                        self.desired_col = self.idx_in_sec % self.cols
+                        self.updateSelection()
+                        return
                 sec_idx = next(
                     (
                         i

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -1034,20 +1034,28 @@ class JdExtPage(QtWidgets.QMainWindow):
             base = self.section_paths[self.sec_idx][2]
             current_order = base + self.idx_in_sec
             target_order = 0
-            for h in self.header_orders:
+            header_index = 0
+            for i, h in enumerate(self.header_orders):
                 if h <= current_order:
                     target_order = h
+                    header_index = i
                 else:
                     break
-            target_base = (target_order // 10) * 10
+            start_base = (target_order // 10) * 10
+            start_idx = target_order - start_base
+            if (
+                self.idx_in_sec == start_idx
+                and header_index > 0
+            ):
+                target_order = self.header_orders[header_index - 1]
+                start_base = (target_order // 10) * 10
+                start_idx = target_order - start_base
             sec_idx = next(
-                (i for i, p in enumerate(self.section_paths) if p[2] == target_base),
-                0,
+                (i for i, p in enumerate(self.section_paths) if p[2] == start_base),
+                self.sec_idx,
             )
             self.sec_idx = sec_idx
-            self.idx_in_sec = min(
-                target_order - target_base, len(self.sections[sec_idx]) - 1
-            )
+            self.idx_in_sec = min(start_idx, len(self.sections[sec_idx]) - 1)
             self.desired_col = self.idx_in_sec % self.cols
             self.updateSelection()
 
@@ -1055,29 +1063,35 @@ class JdExtPage(QtWidgets.QMainWindow):
         if not self.in_search_mode and self.sections:
             base = self.section_paths[self.sec_idx][2]
             current_order = base + self.idx_in_sec
-            next_header = None
-            for h in self.header_orders:
+            next_index = None
+            for i, h in enumerate(self.header_orders):
                 if h > current_order:
-                    next_header = h
+                    next_index = i
                     break
-            if next_header is None:
+            if next_index is None:
                 self.sec_idx = len(self.sections) - 1
                 self.idx_in_sec = len(self.sections[self.sec_idx]) - 1
             else:
-                target_order = next_header - 1
-                target_base = (target_order // 10) * 10
+                target_order = self.header_orders[next_index] - 1
+                end_base = (target_order // 10) * 10
+                end_idx = target_order - end_base
+                if (
+                    self.idx_in_sec == end_idx
+                    and next_index + 1 < len(self.header_orders)
+                ):
+                    target_order = self.header_orders[next_index + 1] - 1
+                    end_base = (target_order // 10) * 10
+                    end_idx = target_order - end_base
                 sec_idx = next(
                     (
                         i
                         for i, p in enumerate(self.section_paths)
-                        if p[2] == target_base
+                        if p[2] == end_base
                     ),
                     len(self.sections) - 1,
                 )
                 self.sec_idx = sec_idx
-                self.idx_in_sec = min(
-                    target_order - target_base, len(self.sections[sec_idx]) - 1
-                )
+                self.idx_in_sec = min(end_idx, len(self.sections[sec_idx]) - 1)
             self.desired_col = self.idx_in_sec % self.cols
             self.updateSelection()
 

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -31,6 +31,7 @@ class JdExtPage(QtWidgets.QMainWindow):
         self.sections = []
         self.section_paths = []  # Store (jd_area, jd_id, jd_ext) for each section
         self.section_filenames = []  # Store .2do filenames for sorting
+        self.header_orders = []
         self.sec_idx = 0
         self.idx_in_sec = 0
         self.desired_col = 0
@@ -604,6 +605,7 @@ class JdExtPage(QtWidgets.QMainWindow):
             (self.parent_uuid,),
         )
         headers = cursor.fetchall()
+        self.header_orders = sorted([order for _, order, _ in headers])
         cursor.execute(
             "SELECT tag_id, [order], label FROM state_jd_ext_tags WHERE parent_uuid IS ? ORDER BY [order]",
             (self.parent_uuid,),
@@ -1029,24 +1031,53 @@ class JdExtPage(QtWidgets.QMainWindow):
 
     def moveToSectionStart(self):
         if not self.in_search_mode and self.sections:
-            if self.idx_in_sec == 0 and self.sec_idx > 0:
-                self.sec_idx -= 1
-                self.idx_in_sec = 0
-            else:
-                self.idx_in_sec = 0
-            self.desired_col = 0
+            base = self.section_paths[self.sec_idx][2]
+            current_order = base + self.idx_in_sec
+            target_order = 0
+            for h in self.header_orders:
+                if h <= current_order:
+                    target_order = h
+                else:
+                    break
+            target_base = (target_order // 10) * 10
+            sec_idx = next(
+                (i for i, p in enumerate(self.section_paths) if p[2] == target_base),
+                0,
+            )
+            self.sec_idx = sec_idx
+            self.idx_in_sec = min(
+                target_order - target_base, len(self.sections[sec_idx]) - 1
+            )
+            self.desired_col = self.idx_in_sec % self.cols
             self.updateSelection()
 
     def moveToSectionEnd(self):
         if not self.in_search_mode and self.sections:
-            sec = self.sections[self.sec_idx]
-            last_idx = len(sec) - 1
-            if self.idx_in_sec == last_idx and self.sec_idx < len(self.sections) - 1:
-                self.sec_idx += 1
-                sec = self.sections[self.sec_idx]
-                self.idx_in_sec = len(sec) - 1
+            base = self.section_paths[self.sec_idx][2]
+            current_order = base + self.idx_in_sec
+            next_header = None
+            for h in self.header_orders:
+                if h > current_order:
+                    next_header = h
+                    break
+            if next_header is None:
+                self.sec_idx = len(self.sections) - 1
+                self.idx_in_sec = len(self.sections[self.sec_idx]) - 1
             else:
-                self.idx_in_sec = last_idx
+                target_order = next_header - 1
+                target_base = (target_order // 10) * 10
+                sec_idx = next(
+                    (
+                        i
+                        for i, p in enumerate(self.section_paths)
+                        if p[2] == target_base
+                    ),
+                    len(self.sections) - 1,
+                )
+                self.sec_idx = sec_idx
+                self.idx_in_sec = min(
+                    target_order - target_base, len(self.sections[sec_idx]) - 1
+                )
             self.desired_col = self.idx_in_sec % self.cols
             self.updateSelection()
 

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -30,6 +30,7 @@ class JdIdPage(QtWidgets.QMainWindow):
         self.sections = []
         self.section_paths = []  # Store (jd_area, jd_id, jd_ext) for each section
         self.section_filenames = []  # Store .2do filenames for sorting
+        self.header_orders = []
         self.sec_idx = 0
         self.idx_in_sec = 0
         self.desired_col = 0
@@ -585,6 +586,7 @@ class JdIdPage(QtWidgets.QMainWindow):
             (self.parent_uuid,),
         )
         headers = cursor.fetchall()
+        self.header_orders = sorted([order for _, order, _ in headers])
         cursor.execute(
             "SELECT tag_id, [order], label FROM state_jd_id_tags WHERE parent_uuid IS ? ORDER BY [order]",
             (self.parent_uuid,),
@@ -958,24 +960,53 @@ class JdIdPage(QtWidgets.QMainWindow):
 
     def moveToSectionStart(self):
         if not self.in_search_mode and self.sections:
-            if self.idx_in_sec == 0 and self.sec_idx > 0:
-                self.sec_idx -= 1
-                self.idx_in_sec = 0
-            else:
-                self.idx_in_sec = 0
-            self.desired_col = 0
+            base = self.section_paths[self.sec_idx][1]
+            current_order = base + self.idx_in_sec
+            target_order = 0
+            for h in self.header_orders:
+                if h <= current_order:
+                    target_order = h
+                else:
+                    break
+            target_base = (target_order // 10) * 10
+            sec_idx = next(
+                (i for i, p in enumerate(self.section_paths) if p[1] == target_base),
+                0,
+            )
+            self.sec_idx = sec_idx
+            self.idx_in_sec = min(
+                target_order - target_base, len(self.sections[sec_idx]) - 1
+            )
+            self.desired_col = self.idx_in_sec % self.cols
             self.updateSelection()
 
     def moveToSectionEnd(self):
         if not self.in_search_mode and self.sections:
-            sec = self.sections[self.sec_idx]
-            last_idx = len(sec) - 1
-            if self.idx_in_sec == last_idx and self.sec_idx < len(self.sections) - 1:
-                self.sec_idx += 1
-                sec = self.sections[self.sec_idx]
-                self.idx_in_sec = len(sec) - 1
+            base = self.section_paths[self.sec_idx][1]
+            current_order = base + self.idx_in_sec
+            next_header = None
+            for h in self.header_orders:
+                if h > current_order:
+                    next_header = h
+                    break
+            if next_header is None:
+                self.sec_idx = len(self.sections) - 1
+                self.idx_in_sec = len(self.sections[self.sec_idx]) - 1
             else:
-                self.idx_in_sec = last_idx
+                target_order = next_header - 1
+                target_base = (target_order // 10) * 10
+                sec_idx = next(
+                    (
+                        i
+                        for i, p in enumerate(self.section_paths)
+                        if p[1] == target_base
+                    ),
+                    len(self.sections) - 1,
+                )
+                self.sec_idx = sec_idx
+                self.idx_in_sec = min(
+                    target_order - target_base, len(self.sections[sec_idx]) - 1
+                )
             self.desired_col = self.idx_in_sec % self.cols
             self.updateSelection()
 

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -586,7 +586,7 @@ class JdIdPage(QtWidgets.QMainWindow):
             (self.parent_uuid,),
         )
         headers = cursor.fetchall()
-        self.header_orders = sorted([order for _, order, _ in headers])
+        self.header_orders = sorted({0, *(order for _, order, _ in headers)})
         cursor.execute(
             "SELECT tag_id, [order], label FROM state_jd_id_tags WHERE parent_uuid IS ? ORDER BY [order]",
             (self.parent_uuid,),
@@ -1004,13 +1004,17 @@ class JdIdPage(QtWidgets.QMainWindow):
                 target_order = self.header_orders[next_index] - 1
                 end_base = (target_order // 10) * 10
                 end_idx = target_order - end_base
-                if (
-                    self.idx_in_sec == end_idx
-                    and next_index + 1 < len(self.header_orders)
-                ):
-                    target_order = self.header_orders[next_index + 1] - 1
-                    end_base = (target_order // 10) * 10
-                    end_idx = target_order - end_base
+                if self.idx_in_sec == end_idx:
+                    if next_index + 1 < len(self.header_orders):
+                        target_order = self.header_orders[next_index + 1] - 1
+                        end_base = (target_order // 10) * 10
+                        end_idx = target_order - end_base
+                    else:
+                        self.sec_idx = len(self.sections) - 1
+                        self.idx_in_sec = len(self.sections[self.sec_idx]) - 1
+                        self.desired_col = self.idx_in_sec % self.cols
+                        self.updateSelection()
+                        return
                 sec_idx = next(
                     (
                         i

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -963,20 +963,28 @@ class JdIdPage(QtWidgets.QMainWindow):
             base = self.section_paths[self.sec_idx][1]
             current_order = base + self.idx_in_sec
             target_order = 0
-            for h in self.header_orders:
+            header_index = 0
+            for i, h in enumerate(self.header_orders):
                 if h <= current_order:
                     target_order = h
+                    header_index = i
                 else:
                     break
-            target_base = (target_order // 10) * 10
+            start_base = (target_order // 10) * 10
+            start_idx = target_order - start_base
+            if (
+                self.idx_in_sec == start_idx
+                and header_index > 0
+            ):
+                target_order = self.header_orders[header_index - 1]
+                start_base = (target_order // 10) * 10
+                start_idx = target_order - start_base
             sec_idx = next(
-                (i for i, p in enumerate(self.section_paths) if p[1] == target_base),
-                0,
+                (i for i, p in enumerate(self.section_paths) if p[1] == start_base),
+                self.sec_idx,
             )
             self.sec_idx = sec_idx
-            self.idx_in_sec = min(
-                target_order - target_base, len(self.sections[sec_idx]) - 1
-            )
+            self.idx_in_sec = min(start_idx, len(self.sections[sec_idx]) - 1)
             self.desired_col = self.idx_in_sec % self.cols
             self.updateSelection()
 
@@ -984,29 +992,35 @@ class JdIdPage(QtWidgets.QMainWindow):
         if not self.in_search_mode and self.sections:
             base = self.section_paths[self.sec_idx][1]
             current_order = base + self.idx_in_sec
-            next_header = None
-            for h in self.header_orders:
+            next_index = None
+            for i, h in enumerate(self.header_orders):
                 if h > current_order:
-                    next_header = h
+                    next_index = i
                     break
-            if next_header is None:
+            if next_index is None:
                 self.sec_idx = len(self.sections) - 1
                 self.idx_in_sec = len(self.sections[self.sec_idx]) - 1
             else:
-                target_order = next_header - 1
-                target_base = (target_order // 10) * 10
+                target_order = self.header_orders[next_index] - 1
+                end_base = (target_order // 10) * 10
+                end_idx = target_order - end_base
+                if (
+                    self.idx_in_sec == end_idx
+                    and next_index + 1 < len(self.header_orders)
+                ):
+                    target_order = self.header_orders[next_index + 1] - 1
+                    end_base = (target_order // 10) * 10
+                    end_idx = target_order - end_base
                 sec_idx = next(
                     (
                         i
                         for i, p in enumerate(self.section_paths)
-                        if p[1] == target_base
+                        if p[1] == end_base
                     ),
                     len(self.sections) - 1,
                 )
                 self.sec_idx = sec_idx
-                self.idx_in_sec = min(
-                    target_order - target_base, len(self.sections[sec_idx]) - 1
-                )
+                self.idx_in_sec = min(end_idx, len(self.sections[sec_idx]) - 1)
             self.desired_col = self.idx_in_sec % self.cols
             self.updateSelection()
 


### PR DESCRIPTION
## Summary
- Record header orders on area, ID, and extension pages
- Jump to section start/end using next/previous header instead of row boundaries

## Testing
- `python3 -m py_compile jd_area_page.py jd_id_page.py jd_ext_page.py`

------
https://chatgpt.com/codex/tasks/task_e_689726825f58832ca53a0cbcb89792d1