### PR TITLE
Speed up page navigation by reusing hidden windows

### DIFF
--- a/jdbrowser/__init__.py
+++ b/jdbrowser/__init__.py
@@ -1,5 +1,17 @@
 __version__ = "1.0.0"
 
-# Global pointer to the currently displayed page instance.
-# This can hold a JdAreaPage, JdIdPage or JdExtPage.
+"""Package level state for the UI pages.
+
+``current_page`` holds a reference to the page that is currently visible.
+``page_stack`` keeps the previously shown pages so they can be restored without
+being reconstructed, allowing faster navigation between pages.
+"""
+
+# Global pointer to the currently displayed page instance. This can hold a
+# ``JdAreaPage``, ``JdIdPage`` or ``JdExtPage``.
 current_page = None
+
+# Stack of previously visited pages to enable reusing them when navigating
+# back.  This avoids recreating the heavy Qt widgets each time, reducing the
+# perceived slowness when swapping between pages.
+page_stack = []

--- a/jdbrowser/jd_area_page.py
+++ b/jdbrowser/jd_area_page.py
@@ -1072,11 +1072,14 @@ class JdAreaPage(QtWidgets.QMainWindow):
         if not current_item.tag_id:
             return
 
-        # Instantiate the next level page and replace the current one
+        # Instantiate the next level page and replace the current one.  Instead
+        # of destroying this page, keep it on a stack so that navigating back is
+        # instantaneous.
+        jdbrowser.page_stack.append(self)
         new_page = JdIdPage(parent_uuid=current_item.tag_id, jd_area=current_item.jd_area)
         jdbrowser.current_page = new_page
         new_page.show()
-        self.close()
+        self.hide()
 
     def updateSelection(self):
         if self.sections and 0 <= self.sec_idx < len(self.sections) and 0 <= self.idx_in_sec < len(self.sections[self.sec_idx]):

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -341,11 +341,11 @@ class JdExtPage(QtWidgets.QMainWindow):
                 break
 
     def ascend_level(self):
-        from .jd_id_page import JdIdPage
-
-        new_page = JdIdPage(parent_uuid=self.grandparent_uuid, jd_area=self.current_jd_area)
-        jdbrowser.current_page = new_page
-        new_page.show()
+        """Return to the previous page in the navigation stack."""
+        if jdbrowser.page_stack:
+            previous_page = jdbrowser.page_stack.pop()
+            jdbrowser.current_page = previous_page
+            previous_page.show()
         self.close()
 
     def _edit_tag_label_with_icon(self):

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -336,10 +336,11 @@ class JdIdPage(QtWidgets.QMainWindow):
                 break
 
     def ascend_level(self):
-        from .jd_area_page import JdAreaPage
-        new_page = JdAreaPage()
-        jdbrowser.current_page = new_page
-        new_page.show()
+        """Return to the previous page if one exists on the stack."""
+        if jdbrowser.page_stack:
+            previous_page = jdbrowser.page_stack.pop()
+            jdbrowser.current_page = previous_page
+            previous_page.show()
         self.close()
 
     def _edit_tag_label_with_icon(self):
@@ -1096,6 +1097,10 @@ class JdIdPage(QtWidgets.QMainWindow):
         if not current_item.tag_id:
             return
         from .jd_ext_page import JdExtPage
+
+        # Keep this page on the stack so returning from the extension level is
+        # fast and preserves state.
+        jdbrowser.page_stack.append(self)
         new_page = JdExtPage(
             parent_uuid=current_item.tag_id,
             jd_area=current_item.jd_area,
@@ -1104,7 +1109,7 @@ class JdIdPage(QtWidgets.QMainWindow):
         )
         jdbrowser.current_page = new_page
         new_page.show()
-        self.close()
+        self.hide()
 
     def updateSelection(self):
         if self.sections and 0 <= self.sec_idx < len(self.sections) and 0 <= self.idx_in_sec < len(self.sections[self.sec_idx]):


### PR DESCRIPTION
## Summary
- cache page instances in a new `page_stack` to avoid reconstructing windows when navigating
- update page transitions to push/hide current page and show previous one from the stack

## Testing
- `python3 -m py_compile jdbrowser/__init__.py jdbrowser/jd_area_page.py jdbrowser/jd_id_page.py jdbrowser/jd_ext_page.py`
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_689818db69ec832c9e742754098bf8e3