### PR TITLE
Add placeholder directory list page

### DIFF
--- a/jdbrowser/__init__.py
+++ b/jdbrowser/__init__.py
@@ -1,5 +1,5 @@
 __version__ = "1.0.0"
 
 # Global pointer to the currently displayed page instance.
-# This can hold a JdAreaPage, JdIdPage or JdExtPage.
+# This can hold a JdAreaPage, JdIdPage, JdExtPage or JdDirectoryListPage.
 current_page = None

--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -1,0 +1,72 @@
+from PySide6 import QtWidgets, QtGui, QtCore
+import jdbrowser
+
+class JdDirectoryListPage(QtWidgets.QMainWindow):
+    def __init__(
+        self,
+        parent_uuid,
+        jd_area,
+        jd_id,
+        jd_ext,
+        grandparent_uuid,
+        great_grandparent_uuid,
+    ):
+        super().__init__()
+        self.parent_uuid = parent_uuid
+        self.current_jd_area = jd_area
+        self.current_jd_id = jd_id
+        self.current_jd_ext = jd_ext
+        self.grandparent_uuid = grandparent_uuid
+        self.great_grandparent_uuid = great_grandparent_uuid
+        self.setWindowTitle(
+            f"File Browser - [{jd_area:02d}.{jd_id:02d}+{jd_ext:04d}]"
+        )
+        self.setWindowFlags(QtCore.Qt.FramelessWindowHint)
+        central = QtWidgets.QWidget()
+        central.setStyleSheet("background-color: black;")
+        self.setCentralWidget(central)
+        self._setup_shortcuts()
+
+    def ascend_level(self):
+        from .jd_ext_page import JdExtPage
+
+        new_page = JdExtPage(
+            parent_uuid=self.grandparent_uuid,
+            jd_area=self.current_jd_area,
+            jd_id=self.current_jd_id,
+            grandparent_uuid=self.great_grandparent_uuid,
+        )
+        jdbrowser.current_page = new_page
+        new_page.show()
+        self.close()
+
+    def _setup_shortcuts(self):
+        self.setFocusPolicy(QtCore.Qt.FocusPolicy.StrongFocus)
+        mappings = [
+            (QtCore.Qt.Key_Backspace, self.ascend_level, None),
+            (
+                QtCore.Qt.Key_Up,
+                self.ascend_level,
+                None,
+                QtCore.Qt.KeyboardModifier.AltModifier,
+            ),
+        ]
+        self.shortcuts = []
+        for mapping in mappings:
+            key, func, arg = mapping[0], mapping[1], mapping[2]
+            modifiers = (
+                mapping[3]
+                if len(mapping) > 3
+                else QtCore.Qt.KeyboardModifier.NoModifier
+            )
+            shortcut = QtGui.QShortcut(QtGui.QKeySequence(key | modifiers), self)
+            if arg is None:
+                shortcut.activated.connect(func)
+            else:
+                shortcut.activated.connect(lambda f=func, a=arg: f(a))
+            self.shortcuts.append(shortcut)
+        quit_keys = ["Q", "Ctrl+Q", "Ctrl+W", "Alt+F4"]
+        for seq in quit_keys:
+            s = QtGui.QShortcut(QtGui.QKeySequence(seq), self)
+            s.activated.connect(self.close)
+            self.shortcuts.append(s)

--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -25,6 +25,10 @@ class JdDirectoryListPage(QtWidgets.QMainWindow):
         central = QtWidgets.QWidget()
         central.setStyleSheet("background-color: black;")
         self.setCentralWidget(central)
+        settings = QtCore.QSettings("xAI", "jdbrowser")
+        if settings.contains("pos") and settings.contains("size"):
+            self.move(settings.value("pos", type=QtCore.QPoint))
+            self.resize(settings.value("size", type=QtCore.QSize))
         self._setup_shortcuts()
 
     def ascend_level(self):
@@ -36,6 +40,7 @@ class JdDirectoryListPage(QtWidgets.QMainWindow):
             jd_id=self.current_jd_id,
             grandparent_uuid=self.great_grandparent_uuid,
         )
+        new_page.setGeometry(self.geometry())
         jdbrowser.current_page = new_page
         new_page.show()
         self.close()
@@ -70,3 +75,9 @@ class JdDirectoryListPage(QtWidgets.QMainWindow):
             s = QtGui.QShortcut(QtGui.QKeySequence(seq), self)
             s.activated.connect(self.close)
             self.shortcuts.append(s)
+
+    def closeEvent(self, event):
+        settings = QtCore.QSettings("xAI", "jdbrowser")
+        settings.setValue("pos", self.pos())
+        settings.setValue("size", self.size())
+        super().closeEvent(event)

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -1107,7 +1107,28 @@ class JdExtPage(QtWidgets.QMainWindow):
             self.updateSelection()
 
     def descend_level(self):
-        pass
+        if not self.sections:
+            return
+        if not (0 <= self.sec_idx < len(self.sections)):
+            return
+        sec = self.sections[self.sec_idx]
+        if not (0 <= self.idx_in_sec < len(sec)):
+            return
+        current_item = sec[self.idx_in_sec]
+        if not current_item.tag_id:
+            return
+        from .jd_directory_list_page import JdDirectoryListPage
+        new_page = JdDirectoryListPage(
+            parent_uuid=current_item.tag_id,
+            jd_area=current_item.jd_area,
+            jd_id=current_item.jd_id,
+            jd_ext=current_item.jd_ext,
+            grandparent_uuid=self.parent_uuid,
+            great_grandparent_uuid=self.grandparent_uuid,
+        )
+        jdbrowser.current_page = new_page
+        new_page.show()
+        self.close()
 
     def updateSelection(self):
         if self.sections and 0 <= self.sec_idx < len(self.sections) and 0 <= self.idx_in_sec < len(self.sections[self.sec_idx]):

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -1126,6 +1126,7 @@ class JdExtPage(QtWidgets.QMainWindow):
             grandparent_uuid=self.parent_uuid,
             great_grandparent_uuid=self.grandparent_uuid,
         )
+        new_page.setGeometry(self.geometry())
         jdbrowser.current_page = new_page
         new_page.show()
         self.close()


### PR DESCRIPTION
## Summary
- Introduce empty black `JdDirectoryListPage` reachable from `JdExtPage`
- Enable returning to `JdExtPage` using Backspace or Alt+Up
- Document new page type in module globals

## Testing
- `pyenv shell 3.10.17 && python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689821841944832c8d15be9c8580d42c