### PR TITLE
Use single Qt window for all pages

### DIFF
--- a/jdbrowser/__init__.py
+++ b/jdbrowser/__init__.py
@@ -1,5 +1,8 @@
 __version__ = "1.0.0"
 
-# Global pointer to the currently displayed page instance.
+# Global pointer to the main application window.
+main_window = None
+
+# Global pointer to the currently displayed page widget.
 # This can hold a JdAreaPage, JdIdPage, JdExtPage or JdDirectoryListPage.
 current_page = None

--- a/jdbrowser/jd_area_page.py
+++ b/jdbrowser/jd_area_page.py
@@ -538,12 +538,12 @@ class JdAreaPage(QtWidgets.QWidget):
             self.search_shortcut_instances.append(s)
 
     def _setup_ui(self):
-        if not hasattr(self, "scroll"):
-            self.scroll = QtWidgets.QScrollArea()
-            self.scroll.setWidgetResizable(True)
+        if not hasattr(self, "scroll_area"):
+            self.scroll_area = QtWidgets.QScrollArea()
+            self.scroll_area.setWidgetResizable(True)
             layout = QtWidgets.QVBoxLayout(self)
             layout.setContentsMargins(0, 0, 0, 0)
-            layout.addWidget(self.scroll)
+            layout.addWidget(self.scroll_area)
 
             # Search input box
             self.search_input = SearchLineEdit(self)
@@ -553,7 +553,7 @@ class JdAreaPage(QtWidgets.QWidget):
             self.search_input.textChanged.connect(self.perform_search)
             self._setup_search_shortcuts()
         else:
-            old = self.scroll.takeWidget()
+            old = self.scroll_area.takeWidget()
             if old:
                 old.deleteLater()
 
@@ -617,7 +617,7 @@ class JdAreaPage(QtWidgets.QWidget):
             for obj_id, order, label, prefix in headers_by_base.get(base, []):
                 display = f"{prefix} {label}" if prefix else (label or "")
                 header_item = HeaderItem(obj_id, order, None, None, label, self, section_index, display)
-                header_item.setMinimumWidth(self.scroll.viewport().width() - 10)
+                header_item.setMinimumWidth(self.scroll_area.viewport().width() - 10)
                 mainLayout.addWidget(header_item)
                 mainLayout.addSpacing(10)
             section = [
@@ -670,7 +670,7 @@ class JdAreaPage(QtWidgets.QWidget):
         mainLayout.addStretch()
         container.setStyleSheet(f'background-color: #000000;')
         container.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
-        self.scroll.setWidget(container)
+        self.scroll_area.setWidget(container)
 
         self.search_input.move(self.width() - 310, self.height() - 40)
 
@@ -698,7 +698,7 @@ class JdAreaPage(QtWidgets.QWidget):
         current_tag_id = None
         if self.sections and 0 <= self.sec_idx < len(self.sections) and 0 <= self.idx_in_sec < len(self.sections[self.sec_idx]):
             current_tag_id = self.sections[self.sec_idx][self.idx_in_sec].tag_id
-        old_widget = self.scroll.takeWidget()
+        old_widget = self.scroll_area.takeWidget()
         if old_widget:
             old_widget.deleteLater()
         self.sections = []
@@ -1027,12 +1027,12 @@ class JdAreaPage(QtWidgets.QWidget):
     def centerSelectedItem(self):
         if not self.in_search_mode and self.sections:
             current = self.sections[self.sec_idx][self.idx_in_sec]
-            self.scroll.ensureWidgetVisible(current)
-            viewport = self.scroll.viewport()
+            self.scroll_area.ensureWidgetVisible(current)
+            viewport = self.scroll_area.viewport()
             viewport_height = viewport.height()
             widget_rect = current.rect()
-            widget_pos = current.mapTo(self.scroll.widget(), widget_rect.topLeft())
-            scroll_bar = self.scroll.verticalScrollBar()
+            widget_pos = current.mapTo(self.scroll_area.widget(), widget_rect.topLeft())
+            scroll_bar = self.scroll_area.verticalScrollBar()
             target_pos = widget_pos.y() - (viewport_height - widget_rect.height()) // 2
             scroll_bar.setValue(max(0, target_pos))
             self.updateSelection()
@@ -1082,7 +1082,7 @@ class JdAreaPage(QtWidgets.QWidget):
     def updateSelection(self):
         if self.sections and 0 <= self.sec_idx < len(self.sections) and 0 <= self.idx_in_sec < len(self.sections[self.sec_idx]):
             current = self.sections[self.sec_idx][self.idx_in_sec]
-            self.scroll.ensureWidgetVisible(current)
+            self.scroll_area.ensureWidgetVisible(current)
             for s, sec in enumerate(self.sections):
                 for i, item in enumerate(sec):
                     item.isSelected = (s == self.sec_idx and i == self.idx_in_sec)
@@ -1103,7 +1103,7 @@ class JdAreaPage(QtWidgets.QWidget):
     def resizeEvent(self, event):
         self.search_input.move(self.width() - 310, self.height() - 40)
         # Update header widths on resize
-        for widget in self.scroll.widget().findChildren(QtWidgets.QLabel):
+        for widget in self.scroll_area.widget().findChildren(QtWidgets.QLabel):
             if widget.styleSheet().startswith(f'background-color: {BUTTON_COLOR}'):
-                widget.setMinimumWidth(self.scroll.viewport().width() - 10)
+                widget.setMinimumWidth(self.scroll_area.viewport().width() - 10)
         super().resizeEvent(event)

--- a/jdbrowser/jd_area_page.py
+++ b/jdbrowser/jd_area_page.py
@@ -538,8 +538,25 @@ class JdAreaPage(QtWidgets.QWidget):
             self.search_shortcut_instances.append(s)
 
     def _setup_ui(self):
-        self.scroll = QtWidgets.QScrollArea()
-        self.scroll.setWidgetResizable(True)
+        if not hasattr(self, "scroll"):
+            self.scroll = QtWidgets.QScrollArea()
+            self.scroll.setWidgetResizable(True)
+            layout = QtWidgets.QVBoxLayout(self)
+            layout.setContentsMargins(0, 0, 0, 0)
+            layout.addWidget(self.scroll)
+
+            # Search input box
+            self.search_input = SearchLineEdit(self)
+            self.search_input.setFixedWidth(300)
+            self.search_input.setFixedHeight(30)
+            self.search_input.hide()
+            self.search_input.textChanged.connect(self.perform_search)
+            self._setup_search_shortcuts()
+        else:
+            old = self.scroll.takeWidget()
+            if old:
+                old.deleteLater()
+
         container = QtWidgets.QWidget()
         mainLayout = QtWidgets.QVBoxLayout(container)
         mainLayout.setSpacing(10)
@@ -654,18 +671,7 @@ class JdAreaPage(QtWidgets.QWidget):
         container.setStyleSheet(f'background-color: #000000;')
         container.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
         self.scroll.setWidget(container)
-        layout = QtWidgets.QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self.scroll)
 
-        # Search input box
-        self.search_input = SearchLineEdit(self)
-        self.search_input.setFixedWidth(300)
-        self.search_input.setFixedHeight(30)
-        self.search_input.hide()
-        self.search_input.textChanged.connect(self.perform_search)
-
-        self._setup_search_shortcuts()
         self.search_input.move(self.width() - 310, self.height() - 40)
 
         style = f'''

--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -22,6 +22,7 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             jdbrowser.main_window.setWindowTitle(
                 f"File Browser - [{jd_area:02d}.{jd_id:02d}+{jd_ext:04d}]"
             )
+        self.setAttribute(QtCore.Qt.WA_StyledBackground, True)
         self.setStyleSheet("background-color: black;")
         self._setup_shortcuts()
 

--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -1,7 +1,7 @@
 from PySide6 import QtWidgets, QtGui, QtCore
 import jdbrowser
 
-class JdDirectoryListPage(QtWidgets.QMainWindow):
+class JdDirectoryListPage(QtWidgets.QWidget):
     def __init__(
         self,
         parent_uuid,
@@ -18,17 +18,11 @@ class JdDirectoryListPage(QtWidgets.QMainWindow):
         self.current_jd_ext = jd_ext
         self.grandparent_uuid = grandparent_uuid
         self.great_grandparent_uuid = great_grandparent_uuid
-        self.setWindowTitle(
-            f"File Browser - [{jd_area:02d}.{jd_id:02d}+{jd_ext:04d}]"
-        )
-        self.setWindowFlags(QtCore.Qt.FramelessWindowHint)
-        central = QtWidgets.QWidget()
-        central.setStyleSheet("background-color: black;")
-        self.setCentralWidget(central)
-        settings = QtCore.QSettings("xAI", "jdbrowser")
-        if settings.contains("pos") and settings.contains("size"):
-            self.move(settings.value("pos", type=QtCore.QPoint))
-            self.resize(settings.value("size", type=QtCore.QSize))
+        if jdbrowser.main_window:
+            jdbrowser.main_window.setWindowTitle(
+                f"File Browser - [{jd_area:02d}.{jd_id:02d}+{jd_ext:04d}]"
+            )
+        self.setStyleSheet("background-color: black;")
         self._setup_shortcuts()
 
     def ascend_level(self):
@@ -40,10 +34,8 @@ class JdDirectoryListPage(QtWidgets.QMainWindow):
             jd_id=self.current_jd_id,
             grandparent_uuid=self.great_grandparent_uuid,
         )
-        new_page.setGeometry(self.geometry())
         jdbrowser.current_page = new_page
-        new_page.show()
-        self.close()
+        jdbrowser.main_window.setCentralWidget(new_page)
 
     def _setup_shortcuts(self):
         self.setFocusPolicy(QtCore.Qt.FocusPolicy.StrongFocus)
@@ -73,11 +65,5 @@ class JdDirectoryListPage(QtWidgets.QMainWindow):
         quit_keys = ["Q", "Ctrl+Q", "Ctrl+W", "Alt+F4"]
         for seq in quit_keys:
             s = QtGui.QShortcut(QtGui.QKeySequence(seq), self)
-            s.activated.connect(self.close)
+            s.activated.connect(jdbrowser.main_window.close)
             self.shortcuts.append(s)
-
-    def closeEvent(self, event):
-        settings = QtCore.QSettings("xAI", "jdbrowser")
-        settings.setValue("pos", self.pos())
-        settings.setValue("size", self.size())
-        super().closeEvent(event)

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -580,8 +580,25 @@ class JdExtPage(QtWidgets.QWidget):
             self.search_shortcut_instances.append(s)
 
     def _setup_ui(self):
-        self.scroll = QtWidgets.QScrollArea()
-        self.scroll.setWidgetResizable(True)
+        if not hasattr(self, "scroll"):
+            self.scroll = QtWidgets.QScrollArea()
+            self.scroll.setWidgetResizable(True)
+            layout = QtWidgets.QVBoxLayout(self)
+            layout.setContentsMargins(0, 0, 0, 0)
+            layout.addWidget(self.scroll)
+
+            # Search input box
+            self.search_input = SearchLineEdit(self)
+            self.search_input.setFixedWidth(300)
+            self.search_input.setFixedHeight(30)
+            self.search_input.hide()
+            self.search_input.textChanged.connect(self.perform_search)
+            self._setup_search_shortcuts()
+        else:
+            old = self.scroll.takeWidget()
+            if old:
+                old.deleteLater()
+
         container = QtWidgets.QWidget()
         mainLayout = QtWidgets.QVBoxLayout(container)
         mainLayout.setSpacing(10)
@@ -729,18 +746,7 @@ class JdExtPage(QtWidgets.QWidget):
         container.setStyleSheet(f'background-color: #000000;')
         container.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
         self.scroll.setWidget(container)
-        layout = QtWidgets.QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self.scroll)
 
-        # Search input box
-        self.search_input = SearchLineEdit(self)
-        self.search_input.setFixedWidth(300)
-        self.search_input.setFixedHeight(30)
-        self.search_input.hide()
-        self.search_input.textChanged.connect(self.perform_search)
-
-        self._setup_search_shortcuts()
         self.search_input.move(self.width() - 310, self.height() - 40)
 
         style = f'''

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -580,12 +580,12 @@ class JdExtPage(QtWidgets.QWidget):
             self.search_shortcut_instances.append(s)
 
     def _setup_ui(self):
-        if not hasattr(self, "scroll"):
-            self.scroll = QtWidgets.QScrollArea()
-            self.scroll.setWidgetResizable(True)
+        if not hasattr(self, "scroll_area"):
+            self.scroll_area = QtWidgets.QScrollArea()
+            self.scroll_area.setWidgetResizable(True)
             layout = QtWidgets.QVBoxLayout(self)
             layout.setContentsMargins(0, 0, 0, 0)
-            layout.addWidget(self.scroll)
+            layout.addWidget(self.scroll_area)
 
             # Search input box
             self.search_input = SearchLineEdit(self)
@@ -595,7 +595,7 @@ class JdExtPage(QtWidgets.QWidget):
             self.search_input.textChanged.connect(self.perform_search)
             self._setup_search_shortcuts()
         else:
-            old = self.scroll.takeWidget()
+            old = self.scroll_area.takeWidget()
             if old:
                 old.deleteLater()
 
@@ -715,7 +715,7 @@ class JdExtPage(QtWidgets.QWidget):
                     section_index,
                     display,
                 )
-                header_item.setMinimumWidth(self.scroll.viewport().width() - 10)
+                header_item.setMinimumWidth(self.scroll_area.viewport().width() - 10)
                 mainLayout.addWidget(header_item)
                 mainLayout.addSpacing(10)
                 last_header_id = obj_id
@@ -745,7 +745,7 @@ class JdExtPage(QtWidgets.QWidget):
         mainLayout.addStretch()
         container.setStyleSheet(f'background-color: #000000;')
         container.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
-        self.scroll.setWidget(container)
+        self.scroll_area.setWidget(container)
 
         self.search_input.move(self.width() - 310, self.height() - 40)
 
@@ -773,7 +773,7 @@ class JdExtPage(QtWidgets.QWidget):
         current_tag_id = None
         if self.sections and 0 <= self.sec_idx < len(self.sections) and 0 <= self.idx_in_sec < len(self.sections[self.sec_idx]):
             current_tag_id = self.sections[self.sec_idx][self.idx_in_sec].tag_id
-        old_widget = self.scroll.takeWidget()
+        old_widget = self.scroll_area.takeWidget()
         if old_widget:
             old_widget.deleteLater()
         self.sections = []
@@ -1074,12 +1074,12 @@ class JdExtPage(QtWidgets.QWidget):
     def centerSelectedItem(self):
         if not self.in_search_mode and self.sections:
             current = self.sections[self.sec_idx][self.idx_in_sec]
-            self.scroll.ensureWidgetVisible(current)
-            viewport = self.scroll.viewport()
+            self.scroll_area.ensureWidgetVisible(current)
+            viewport = self.scroll_area.viewport()
             viewport_height = viewport.height()
             widget_rect = current.rect()
-            widget_pos = current.mapTo(self.scroll.widget(), widget_rect.topLeft())
-            scroll_bar = self.scroll.verticalScrollBar()
+            widget_pos = current.mapTo(self.scroll_area.widget(), widget_rect.topLeft())
+            scroll_bar = self.scroll_area.verticalScrollBar()
             target_pos = widget_pos.y() - (viewport_height - widget_rect.height()) // 2
             scroll_bar.setValue(max(0, target_pos))
             self.updateSelection()
@@ -1134,7 +1134,7 @@ class JdExtPage(QtWidgets.QWidget):
     def updateSelection(self):
         if self.sections and 0 <= self.sec_idx < len(self.sections) and 0 <= self.idx_in_sec < len(self.sections[self.sec_idx]):
             current = self.sections[self.sec_idx][self.idx_in_sec]
-            self.scroll.ensureWidgetVisible(current)
+            self.scroll_area.ensureWidgetVisible(current)
             for s, sec in enumerate(self.sections):
                 for i, item in enumerate(sec):
                     item.isSelected = (s == self.sec_idx and i == self.idx_in_sec)
@@ -1155,7 +1155,7 @@ class JdExtPage(QtWidgets.QWidget):
     def resizeEvent(self, event):
         self.search_input.move(self.width() - 310, self.height() - 40)
         # Update header widths on resize
-        for widget in self.scroll.widget().findChildren(QtWidgets.QLabel):
+        for widget in self.scroll_area.widget().findChildren(QtWidgets.QLabel):
             if widget.styleSheet().startswith(f'background-color: {BUTTON_COLOR}'):
-                widget.setMinimumWidth(self.scroll.viewport().width() - 10)
+                widget.setMinimumWidth(self.scroll_area.viewport().width() - 10)
         super().resizeEvent(event)

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -561,8 +561,25 @@ class JdIdPage(QtWidgets.QWidget):
             self.search_shortcut_instances.append(s)
 
     def _setup_ui(self):
-        self.scroll = QtWidgets.QScrollArea()
-        self.scroll.setWidgetResizable(True)
+        if not hasattr(self, "scroll"):
+            self.scroll = QtWidgets.QScrollArea()
+            self.scroll.setWidgetResizable(True)
+            layout = QtWidgets.QVBoxLayout(self)
+            layout.setContentsMargins(0, 0, 0, 0)
+            layout.addWidget(self.scroll)
+
+            # Search input box
+            self.search_input = SearchLineEdit(self)
+            self.search_input.setFixedWidth(300)
+            self.search_input.setFixedHeight(30)
+            self.search_input.hide()
+            self.search_input.textChanged.connect(self.perform_search)
+            self._setup_search_shortcuts()
+        else:
+            old = self.scroll.takeWidget()
+            if old:
+                old.deleteLater()
+
         container = QtWidgets.QWidget()
         mainLayout = QtWidgets.QVBoxLayout(container)
         mainLayout.setSpacing(10)
@@ -684,18 +701,7 @@ class JdIdPage(QtWidgets.QWidget):
         container.setStyleSheet(f'background-color: #000000;')
         container.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
         self.scroll.setWidget(container)
-        layout = QtWidgets.QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self.scroll)
 
-        # Search input box
-        self.search_input = SearchLineEdit(self)
-        self.search_input.setFixedWidth(300)
-        self.search_input.setFixedHeight(30)
-        self.search_input.hide()
-        self.search_input.textChanged.connect(self.perform_search)
-
-        self._setup_search_shortcuts()
         self.search_input.move(self.width() - 310, self.height() - 40)
 
         style = f'''

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -561,12 +561,12 @@ class JdIdPage(QtWidgets.QWidget):
             self.search_shortcut_instances.append(s)
 
     def _setup_ui(self):
-        if not hasattr(self, "scroll"):
-            self.scroll = QtWidgets.QScrollArea()
-            self.scroll.setWidgetResizable(True)
+        if not hasattr(self, "scroll_area"):
+            self.scroll_area = QtWidgets.QScrollArea()
+            self.scroll_area.setWidgetResizable(True)
             layout = QtWidgets.QVBoxLayout(self)
             layout.setContentsMargins(0, 0, 0, 0)
-            layout.addWidget(self.scroll)
+            layout.addWidget(self.scroll_area)
 
             # Search input box
             self.search_input = SearchLineEdit(self)
@@ -576,7 +576,7 @@ class JdIdPage(QtWidgets.QWidget):
             self.search_input.textChanged.connect(self.perform_search)
             self._setup_search_shortcuts()
         else:
-            old = self.scroll.takeWidget()
+            old = self.scroll_area.takeWidget()
             if old:
                 old.deleteLater()
 
@@ -648,7 +648,7 @@ class JdIdPage(QtWidgets.QWidget):
             for obj_id, order, label, prefix in headers_by_base.get(base, []):
                 display = f"{prefix} {label}" if prefix else (label or "")
                 header_item = HeaderItem(obj_id, self.current_jd_area, order, None, label, self, section_index, display)
-                header_item.setMinimumWidth(self.scroll.viewport().width() - 10)
+                header_item.setMinimumWidth(self.scroll_area.viewport().width() - 10)
                 mainLayout.addWidget(header_item)
                 mainLayout.addSpacing(10)
             section = [
@@ -700,7 +700,7 @@ class JdIdPage(QtWidgets.QWidget):
         mainLayout.addStretch()
         container.setStyleSheet(f'background-color: #000000;')
         container.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
-        self.scroll.setWidget(container)
+        self.scroll_area.setWidget(container)
 
         self.search_input.move(self.width() - 310, self.height() - 40)
 
@@ -728,7 +728,7 @@ class JdIdPage(QtWidgets.QWidget):
         current_tag_id = None
         if self.sections and 0 <= self.sec_idx < len(self.sections) and 0 <= self.idx_in_sec < len(self.sections[self.sec_idx]):
             current_tag_id = self.sections[self.sec_idx][self.idx_in_sec].tag_id
-        old_widget = self.scroll.takeWidget()
+        old_widget = self.scroll_area.takeWidget()
         if old_widget:
             old_widget.deleteLater()
         self.sections = []
@@ -1052,12 +1052,12 @@ class JdIdPage(QtWidgets.QWidget):
     def centerSelectedItem(self):
         if not self.in_search_mode and self.sections:
             current = self.sections[self.sec_idx][self.idx_in_sec]
-            self.scroll.ensureWidgetVisible(current)
-            viewport = self.scroll.viewport()
+            self.scroll_area.ensureWidgetVisible(current)
+            viewport = self.scroll_area.viewport()
             viewport_height = viewport.height()
             widget_rect = current.rect()
-            widget_pos = current.mapTo(self.scroll.widget(), widget_rect.topLeft())
-            scroll_bar = self.scroll.verticalScrollBar()
+            widget_pos = current.mapTo(self.scroll_area.widget(), widget_rect.topLeft())
+            scroll_bar = self.scroll_area.verticalScrollBar()
             target_pos = widget_pos.y() - (viewport_height - widget_rect.height()) // 2
             scroll_bar.setValue(max(0, target_pos))
             self.updateSelection()
@@ -1110,7 +1110,7 @@ class JdIdPage(QtWidgets.QWidget):
     def updateSelection(self):
         if self.sections and 0 <= self.sec_idx < len(self.sections) and 0 <= self.idx_in_sec < len(self.sections[self.sec_idx]):
             current = self.sections[self.sec_idx][self.idx_in_sec]
-            self.scroll.ensureWidgetVisible(current)
+            self.scroll_area.ensureWidgetVisible(current)
             for s, sec in enumerate(self.sections):
                 for i, item in enumerate(sec):
                     item.isSelected = (s == self.sec_idx and i == self.idx_in_sec)
@@ -1131,7 +1131,7 @@ class JdIdPage(QtWidgets.QWidget):
     def resizeEvent(self, event):
         self.search_input.move(self.width() - 310, self.height() - 40)
         # Update header widths on resize
-        for widget in self.scroll.widget().findChildren(QtWidgets.QLabel):
+        for widget in self.scroll_area.widget().findChildren(QtWidgets.QLabel):
             if widget.styleSheet().startswith(f'background-color: {BUTTON_COLOR}'):
-                widget.setMinimumWidth(self.scroll.viewport().width() - 10)
+                widget.setMinimumWidth(self.scroll_area.viewport().width() - 10)
         super().resizeEvent(event)

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import re
 from typing import Union
 
 from PySide6 import QtCore
-from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication, QMainWindow
 from PySide6.QtCore import QSettings, QPoint, QSize
 from PySide6.QtGui import QFont
 
@@ -25,15 +25,31 @@ if __name__ == '__main__':
     app = QApplication(sys.argv)
     app.setFont(QFont('FiraCode Nerd Font'))
 
+    class MainWindow(QMainWindow):
+        def closeEvent(self, event):
+            settings = QSettings("xAI", "jdbrowser")
+            settings.setValue("pos", self.pos())
+            settings.setValue("size", self.size())
+            super().closeEvent(event)
+
+    main_window = MainWindow()
+    main_window.setWindowFlags(QtCore.Qt.FramelessWindowHint)
+    jdbrowser.main_window = main_window
+
     jdbrowser.current_page = JdAreaPage()
     current_page: Union[JdAreaPage, JdIdPage, JdExtPage] = jdbrowser.current_page
+    main_window.setCentralWidget(current_page)
 
     settings = QSettings("xAI", "jdbrowser")
-    if not (settings.contains("pos") and settings.contains("size")):
-        current_page.resize(1000, 600)
+    if settings.contains("pos") and settings.contains("size"):
+        main_window.move(settings.value("pos", type=QPoint))
+        main_window.resize(settings.value("size", type=QSize))
+    else:
+        main_window.resize(1000, 600)
         screen = app.primaryScreen().geometry()
-        current_page.move((screen.width() - 1000) // 2, (screen.height() - 600) // 2)
-    current_page.show()
+        main_window.move((screen.width() - 1000) // 2, (screen.height() - 600) // 2)
+
+    main_window.show()
 
     timer = QtCore.QTimer()
     timer.timeout.connect(lambda: None)


### PR DESCRIPTION
## Summary
- Replaced per-page windows with a single frameless main window
- Refactored JdAreaPage, JdIdPage, JdExtPage and JdDirectoryListPage into widgets
- Navigating now swaps the main window's central widget instead of creating new windows

## Testing
- `python3 -m py_compile main.py jdbrowser/__init__.py jdbrowser/jd_area_page.py jdbrowser/jd_id_page.py jdbrowser/jd_ext_page.py jdbrowser/jd_directory_list_page.py`


------
https://chatgpt.com/codex/tasks/task_e_6898258c160c832c8843a447863cc42e