### PR TITLE
Prevent scrollbar flash during navigation

### DIFF
--- a/jdbrowser/jd_area_page.py
+++ b/jdbrowser/jd_area_page.py
@@ -544,13 +544,13 @@ class JdAreaPage(QtWidgets.QWidget):
             self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
             self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
             QtCore.QTimer.singleShot(
-                0,
+                100,
                 lambda: self.scroll_area.setVerticalScrollBarPolicy(
                     QtCore.Qt.ScrollBarAsNeeded
                 ),
             )
             QtCore.QTimer.singleShot(
-                0,
+                100,
                 lambda: self.scroll_area.setHorizontalScrollBarPolicy(
                     QtCore.Qt.ScrollBarAsNeeded
                 ),

--- a/jdbrowser/jd_area_page.py
+++ b/jdbrowser/jd_area_page.py
@@ -541,6 +541,8 @@ class JdAreaPage(QtWidgets.QWidget):
         if not hasattr(self, "scroll_area"):
             self.scroll_area = QtWidgets.QScrollArea()
             self.scroll_area.setWidgetResizable(True)
+            self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+            self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
             layout = QtWidgets.QVBoxLayout(self)
             layout.setContentsMargins(0, 0, 0, 0)
             layout.addWidget(self.scroll_area)

--- a/jdbrowser/jd_area_page.py
+++ b/jdbrowser/jd_area_page.py
@@ -543,6 +543,18 @@ class JdAreaPage(QtWidgets.QWidget):
             self.scroll_area.setWidgetResizable(True)
             self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
             self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+            QtCore.QTimer.singleShot(
+                0,
+                lambda: self.scroll_area.setVerticalScrollBarPolicy(
+                    QtCore.Qt.ScrollBarAsNeeded
+                ),
+            )
+            QtCore.QTimer.singleShot(
+                0,
+                lambda: self.scroll_area.setHorizontalScrollBarPolicy(
+                    QtCore.Qt.ScrollBarAsNeeded
+                ),
+            )
             layout = QtWidgets.QVBoxLayout(self)
             layout.setContentsMargins(0, 0, 0, 0)
             layout.addWidget(self.scroll_area)

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -586,13 +586,13 @@ class JdExtPage(QtWidgets.QWidget):
             self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
             self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
             QtCore.QTimer.singleShot(
-                0,
+                100,
                 lambda: self.scroll_area.setVerticalScrollBarPolicy(
                     QtCore.Qt.ScrollBarAsNeeded
                 ),
             )
             QtCore.QTimer.singleShot(
-                0,
+                100,
                 lambda: self.scroll_area.setHorizontalScrollBarPolicy(
                     QtCore.Qt.ScrollBarAsNeeded
                 ),

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -585,6 +585,18 @@ class JdExtPage(QtWidgets.QWidget):
             self.scroll_area.setWidgetResizable(True)
             self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
             self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+            QtCore.QTimer.singleShot(
+                0,
+                lambda: self.scroll_area.setVerticalScrollBarPolicy(
+                    QtCore.Qt.ScrollBarAsNeeded
+                ),
+            )
+            QtCore.QTimer.singleShot(
+                0,
+                lambda: self.scroll_area.setHorizontalScrollBarPolicy(
+                    QtCore.Qt.ScrollBarAsNeeded
+                ),
+            )
             layout = QtWidgets.QVBoxLayout(self)
             layout.setContentsMargins(0, 0, 0, 0)
             layout.addWidget(self.scroll_area)

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -583,6 +583,8 @@ class JdExtPage(QtWidgets.QWidget):
         if not hasattr(self, "scroll_area"):
             self.scroll_area = QtWidgets.QScrollArea()
             self.scroll_area.setWidgetResizable(True)
+            self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+            self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
             layout = QtWidgets.QVBoxLayout(self)
             layout.setContentsMargins(0, 0, 0, 0)
             layout.addWidget(self.scroll_area)

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -564,6 +564,8 @@ class JdIdPage(QtWidgets.QWidget):
         if not hasattr(self, "scroll_area"):
             self.scroll_area = QtWidgets.QScrollArea()
             self.scroll_area.setWidgetResizable(True)
+            self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+            self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
             layout = QtWidgets.QVBoxLayout(self)
             layout.setContentsMargins(0, 0, 0, 0)
             layout.addWidget(self.scroll_area)

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -566,6 +566,18 @@ class JdIdPage(QtWidgets.QWidget):
             self.scroll_area.setWidgetResizable(True)
             self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
             self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+            QtCore.QTimer.singleShot(
+                0,
+                lambda: self.scroll_area.setVerticalScrollBarPolicy(
+                    QtCore.Qt.ScrollBarAsNeeded
+                ),
+            )
+            QtCore.QTimer.singleShot(
+                0,
+                lambda: self.scroll_area.setHorizontalScrollBarPolicy(
+                    QtCore.Qt.ScrollBarAsNeeded
+                ),
+            )
             layout = QtWidgets.QVBoxLayout(self)
             layout.setContentsMargins(0, 0, 0, 0)
             layout.addWidget(self.scroll_area)

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -567,13 +567,13 @@ class JdIdPage(QtWidgets.QWidget):
             self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
             self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
             QtCore.QTimer.singleShot(
-                0,
+                100,
                 lambda: self.scroll_area.setVerticalScrollBarPolicy(
                     QtCore.Qt.ScrollBarAsNeeded
                 ),
             )
             QtCore.QTimer.singleShot(
-                0,
+                100,
                 lambda: self.scroll_area.setHorizontalScrollBarPolicy(
                     QtCore.Qt.ScrollBarAsNeeded
                 ),


### PR DESCRIPTION
## Summary
- Hide vertical and horizontal scrollbars on all navigation pages to stop flashing when pages are first displayed

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*
- `python3 -m venv .venv && .venv/bin/pip install pytest` *(fails: Could not find a version that satisfies the requirement pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68982ce3ec30832ca707a8d7de69582c