### PR TITLE
Add directory listing page with large icons and creation shortcut

### DIFF
--- a/jdbrowser/directory_item.py
+++ b/jdbrowser/directory_item.py
@@ -1,0 +1,99 @@
+from PySide6 import QtWidgets, QtGui, QtCore
+from .constants import HIGHLIGHT_COLOR, HOVER_COLOR, SLATE_COLOR, TEXT_COLOR
+
+
+class DirectoryItem(QtWidgets.QWidget):
+    def __init__(self, tag_id, label, icon_data, page, index):
+        super().__init__()
+        self.tag_id = tag_id
+        self.label_text = label if label is not None else ""
+        self.page = page
+        self.index = index
+        self.isSelected = False
+        self.isHover = False
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_Hover)
+
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(5, 5, 5, 5)
+        layout.setSpacing(10)
+
+        if icon_data:
+            pixmap = QtGui.QPixmap()
+            pixmap.loadFromData(icon_data)
+            if not pixmap.isNull():
+                self.icon = QtWidgets.QLabel()
+                rounded_pixmap = QtGui.QPixmap(240, 150)
+                rounded_pixmap.fill(QtCore.Qt.transparent)
+                painter = QtGui.QPainter(rounded_pixmap)
+                painter.setRenderHint(QtGui.QPainter.Antialiasing)
+                path = QtGui.QPainterPath()
+                path.addRoundedRect(0, 0, 240, 150, 5, 5)
+                painter.setClipPath(path)
+                scaled = pixmap.scaled(
+                    240,
+                    150,
+                    QtCore.Qt.AspectRatioMode.KeepAspectRatio,
+                    QtCore.Qt.TransformationMode.SmoothTransformation,
+                )
+                painter.drawPixmap(0, 0, scaled)
+                painter.end()
+                self.icon.setPixmap(rounded_pixmap)
+                self.icon.setFixedSize(240, 150)
+                self.icon.setStyleSheet("background-color: transparent;")
+            else:
+                self.icon = QtWidgets.QFrame()
+                self.icon.setFixedSize(240, 150)
+                self.icon.setStyleSheet(
+                    f"background-color: {SLATE_COLOR}; border-radius: 5px;"
+                )
+        else:
+            self.icon = QtWidgets.QFrame()
+            self.icon.setFixedSize(240, 150)
+            self.icon.setStyleSheet(
+                f"background-color: {SLATE_COLOR}; border-radius: 5px;"
+            )
+        layout.addWidget(self.icon)
+
+        self.right = QtWidgets.QWidget()
+        right_layout = QtWidgets.QVBoxLayout(self.right)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+        right_layout.setSpacing(2)
+
+        self.label = QtWidgets.QLabel(self.label_text)
+        self.label.setAlignment(
+            QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignTop
+        )
+        font = self.label.font()
+        font.setPointSize(int(font.pointSize() * 1.2))
+        font.setBold(True)
+        self.label.setFont(font)
+        self.label.setStyleSheet(f"color: {TEXT_COLOR};")
+        right_layout.addWidget(self.label)
+        right_layout.addStretch(1)
+        layout.addWidget(self.right)
+
+        self.updateStyle()
+
+    def updateStyle(self):
+        bg = HIGHLIGHT_COLOR if self.isSelected else (
+            HOVER_COLOR if self.isHover else "transparent"
+        )
+        self.setStyleSheet(f"background-color: {bg}; border-radius: 5px;")
+
+    def enterEvent(self, event):
+        self.isHover = True
+        self.updateStyle()
+        self.setCursor(QtGui.QCursor(QtCore.Qt.CursorShape.PointingHandCursor))
+        super().enterEvent(event)
+
+    def leaveEvent(self, event):
+        self.isHover = False
+        self.updateStyle()
+        self.setCursor(QtGui.QCursor(QtCore.Qt.CursorShape.ArrowCursor))
+        super().leaveEvent(event)
+
+    def mousePressEvent(self, event):
+        if event.button() == QtCore.Qt.LeftButton and self.page:
+            self.page.set_selection(self.index)
+        super().mousePressEvent(event)
+

--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -1,5 +1,13 @@
+import os
 from PySide6 import QtWidgets, QtGui, QtCore
 import jdbrowser
+from .directory_item import DirectoryItem
+from .database import (
+    setup_database,
+    rebuild_state_jd_directory_tags,
+    create_jd_directory_tag,
+)
+from .constants import *
 
 class JdDirectoryListPage(QtWidgets.QWidget):
     def __init__(
@@ -24,6 +32,17 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             )
         self.setAttribute(QtCore.Qt.WA_StyledBackground, True)
         self.setStyleSheet("background-color: black;")
+
+        xdg_data_home = os.getenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share"))
+        db_dir = os.path.join(xdg_data_home, "jdbrowser")
+        os.makedirs(db_dir, exist_ok=True)
+        self.db_path = os.path.join(db_dir, "tag.db")
+        self.conn = setup_database(self.db_path)
+
+        self.items = []
+        self.selected_index = None
+
+        self._setup_ui()
         self._setup_shortcuts()
 
     def ascend_level(self):
@@ -38,6 +57,78 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         jdbrowser.current_page = new_page
         jdbrowser.main_window.setCentralWidget(new_page)
 
+    def _setup_ui(self):
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(5, 5, 5, 5)
+        layout.setSpacing(5)
+
+        self.scroll_area = QtWidgets.QScrollArea()
+        self.scroll_area.setWidgetResizable(True)
+        self.scroll_area.setStyleSheet("border: none; background-color: transparent;")
+        layout.addWidget(self.scroll_area)
+
+        self.container = QtWidgets.QWidget()
+        self.scroll_area.setWidget(self.container)
+        self.vlayout = QtWidgets.QVBoxLayout(self.container)
+        self.vlayout.setContentsMargins(5, 5, 5, 5)
+        self.vlayout.setSpacing(5)
+
+        self._load_directories()
+
+    def _clear_items(self):
+        while self.vlayout.count():
+            item = self.vlayout.takeAt(0)
+            widget = item.widget()
+            if widget:
+                widget.deleteLater()
+
+    def _load_directories(self):
+        self._clear_items()
+        self.items = []
+        cursor = self.conn.cursor()
+        cursor.execute(
+            """
+            SELECT t.tag_id, t.label, t.[order], i.icon
+            FROM state_jd_directory_tags t
+            LEFT JOIN state_jd_directory_tag_icons i ON t.tag_id = i.tag_id
+            WHERE t.parent_uuid IS ?
+            ORDER BY t.[order]
+            """,
+            (self.parent_uuid,)
+        )
+        rows = cursor.fetchall()
+        for idx, row in enumerate(rows):
+            tag_id, label, order, icon_data = row
+            item = DirectoryItem(tag_id, label, icon_data, self, idx)
+            self.vlayout.addWidget(item)
+            self.items.append(item)
+        self.vlayout.addStretch(1)
+
+    def set_selection(self, index):
+        if not (0 <= index < len(self.items)):
+            return
+        self.selected_index = index
+        for i, item in enumerate(self.items):
+            item.isSelected = i == index
+            item.updateStyle()
+
+    def _add_directory(self):
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "SELECT MAX([order]) FROM state_jd_directory_tags WHERE parent_uuid IS ?",
+            (self.parent_uuid,),
+        )
+        result = cursor.fetchone()
+        max_order = result[0] if result and result[0] is not None else 0
+        new_order = max_order + 1
+        create_jd_directory_tag(self.conn, self.parent_uuid, new_order, "")
+        rebuild_state_jd_directory_tags(self.conn)
+        self._load_directories()
+
+    def closeEvent(self, event):
+        self.conn.close()
+        super().closeEvent(event)
+
     def _setup_shortcuts(self):
         self.setFocusPolicy(QtCore.Qt.FocusPolicy.StrongFocus)
         mappings = [
@@ -48,6 +139,7 @@ class JdDirectoryListPage(QtWidgets.QWidget):
                 None,
                 QtCore.Qt.KeyboardModifier.AltModifier,
             ),
+            (QtCore.Qt.Key_A, self._add_directory, None),
         ]
         self.shortcuts = []
         for mapping in mappings:


### PR DESCRIPTION
## Summary
- Display directory tags as a vertical list with large icons and prominent labels
- Load tag data from SQLite state tables and support creating new tags via `a`
- Introduce reusable `DirectoryItem` widget for styled directory entries

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_689835784c08832c9e6e6ba23bf75da4