### PR TITLE
Default directory selection and selection of new directory items

### DIFF
--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -74,6 +74,8 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         self.vlayout.setSpacing(5)
 
         self._load_directories()
+        if self.items:
+            self.set_selection(0)
 
     def _clear_items(self):
         while self.vlayout.count():
@@ -85,6 +87,7 @@ class JdDirectoryListPage(QtWidgets.QWidget):
     def _load_directories(self):
         self._clear_items()
         self.items = []
+        self.selected_index = None
         cursor = self.conn.cursor()
         cursor.execute(
             """
@@ -150,6 +153,8 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         create_jd_directory_tag(self.conn, self.parent_uuid, new_order, "")
         rebuild_state_jd_directory_tags(self.conn)
         self._load_directories()
+        if self.items:
+            self.set_selection(len(self.items) - 1)
 
     def closeEvent(self, event):
         self.conn.close()


### PR DESCRIPTION
## Summary
- default to selecting the first directory list item when a directory list page loads
- after creating a new directory tag with `a`, make the new entry the current selection
- clear stale selection when reloading directory items

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*
- `pip install pytest --break-system-packages` *(fails: Could not find a version that satisfies the requirement pytest due to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68983b2ababc832cbd8dc01ad6cbe2a7