### PR TITLE
Unify scrollbar styling across pages

### DIFF
--- a/jdbrowser/jd_area_page.py
+++ b/jdbrowser/jd_area_page.py
@@ -702,8 +702,19 @@ class JdAreaPage(QtWidgets.QWidget):
             min-height: 20px;
             border-radius: 4px;
         }}
-        QScrollBar::add-line, QScrollBar::sub-line {{ height: 0; }}
-        QScrollBar::add-page, QScrollBar::sub-page {{ background: none; }}
+        QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {{ height: 0; }}
+        QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {{ background: none; }}
+        QScrollBar:horizontal {{
+            height: 8px;
+            background: #000000;
+        }}
+        QScrollBar::handle:horizontal {{
+            background: {BORDER_COLOR};
+            min-width: 20px;
+            border-radius: 4px;
+        }}
+        QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {{ width: 0; }}
+        QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal {{ background: none; }}
         '''
         self.setStyleSheet(style)
 

--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -31,7 +31,6 @@ class JdDirectoryListPage(QtWidgets.QWidget):
                 f"File Browser - [{jd_area:02d}.{jd_id:02d}+{jd_ext:04d}]"
             )
         self.setAttribute(QtCore.Qt.WA_StyledBackground, True)
-        self.setStyleSheet("background-color: black;")
 
         xdg_data_home = os.getenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share"))
         db_dir = os.path.join(xdg_data_home, "jdbrowser")
@@ -64,10 +63,11 @@ class JdDirectoryListPage(QtWidgets.QWidget):
 
         self.scroll_area = QtWidgets.QScrollArea()
         self.scroll_area.setWidgetResizable(True)
-        self.scroll_area.setStyleSheet("border: none; background-color: transparent;")
+        self.scroll_area.setStyleSheet("border: none; background-color: #000000;")
         layout.addWidget(self.scroll_area)
 
         self.container = QtWidgets.QWidget()
+        self.container.setStyleSheet("background-color: #000000;")
         self.scroll_area.setWidget(self.container)
         self.vlayout = QtWidgets.QVBoxLayout(self.container)
         self.vlayout.setContentsMargins(5, 5, 5, 5)
@@ -76,6 +76,36 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         self._load_directories()
         if self.items:
             self.set_selection(0)
+
+        style = f'''
+        * {{ font-family: 'FiraCode Nerd Font'; }}
+        QWidget {{ background-color: #000000; }}
+        QMainWindow {{ background-color: #000000; }}
+        QScrollArea {{ border: none; background-color: #000000; }}
+        QScrollBar:vertical {{
+            width: 8px;
+            background: #000000;
+        }}
+        QScrollBar::handle:vertical {{
+            background: {BORDER_COLOR};
+            min-height: 20px;
+            border-radius: 4px;
+        }}
+        QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {{ height: 0; }}
+        QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {{ background: none; }}
+        QScrollBar:horizontal {{
+            height: 8px;
+            background: #000000;
+        }}
+        QScrollBar::handle:horizontal {{
+            background: {BORDER_COLOR};
+            min-width: 20px;
+            border-radius: 4px;
+        }}
+        QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {{ width: 0; }}
+        QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal {{ background: none; }}
+        '''
+        self.setStyleSheet(style)
 
     def _clear_items(self):
         while self.vlayout.count():

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -777,8 +777,19 @@ class JdExtPage(QtWidgets.QWidget):
             min-height: 20px;
             border-radius: 4px;
         }}
-        QScrollBar::add-line, QScrollBar::sub-line {{ height: 0; }}
-        QScrollBar::add-page, QScrollBar::sub-page {{ background: none; }}
+        QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {{ height: 0; }}
+        QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {{ background: none; }}
+        QScrollBar:horizontal {{
+            height: 8px;
+            background: #000000;
+        }}
+        QScrollBar::handle:horizontal {{
+            background: {BORDER_COLOR};
+            min-width: 20px;
+            border-radius: 4px;
+        }}
+        QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {{ width: 0; }}
+        QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal {{ background: none; }}
         '''
         self.setStyleSheet(style)
 

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -732,8 +732,19 @@ class JdIdPage(QtWidgets.QWidget):
             min-height: 20px;
             border-radius: 4px;
         }}
-        QScrollBar::add-line, QScrollBar::sub-line {{ height: 0; }}
-        QScrollBar::add-page, QScrollBar::sub-page {{ background: none; }}
+        QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {{ height: 0; }}
+        QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {{ background: none; }}
+        QScrollBar:horizontal {{
+            height: 8px;
+            background: #000000;
+        }}
+        QScrollBar::handle:horizontal {{
+            background: {BORDER_COLOR};
+            min-width: 20px;
+            border-radius: 4px;
+        }}
+        QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {{ width: 0; }}
+        QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal {{ background: none; }}
         '''
         self.setStyleSheet(style)
 


### PR DESCRIPTION
## Summary
- Apply consistent dark-themed scrollbar styling to JdDirectoryListPage.
- Style horizontal scrollbars across all pages to match existing vertical scrollbars.

## Testing
- `PYENV_VERSION=3.11.12 python -m py_compile jdbrowser/jd_area_page.py jdbrowser/jd_ext_page.py jdbrowser/jd_id_page.py jdbrowser/jd_directory_list_page.py`
- `PYENV_VERSION=3.11.12 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689841ec1aa0832c8c0ac76906fd84ee