### PR TITLE
Ensure previous item selected when ascending levels

### DIFF
--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -53,6 +53,19 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             jd_id=self.current_jd_id,
             grandparent_uuid=self.great_grandparent_uuid,
         )
+        # Ensure the item we descended from becomes selected when returning
+        target_tag_id = self.parent_uuid
+        found = False
+        for s, sec in enumerate(new_page.sections):
+            for i, item in enumerate(sec):
+                if item.tag_id == target_tag_id:
+                    new_page.sec_idx = s
+                    new_page.idx_in_sec = i
+                    found = True
+                    break
+            if found:
+                break
+        new_page.updateSelection()
         jdbrowser.current_page = new_page
         jdbrowser.main_window.setCentralWidget(new_page)
 

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -337,6 +337,19 @@ class JdExtPage(QtWidgets.QWidget):
         from .jd_id_page import JdIdPage
 
         new_page = JdIdPage(parent_uuid=self.grandparent_uuid, jd_area=self.current_jd_area)
+        # Select the item we came from in the parent page
+        target_tag_id = self.parent_uuid
+        found = False
+        for s, sec in enumerate(new_page.sections):
+            for i, item in enumerate(sec):
+                if item.tag_id == target_tag_id:
+                    new_page.sec_idx = s
+                    new_page.idx_in_sec = i
+                    found = True
+                    break
+            if found:
+                break
+        new_page.updateSelection()
         self.conn.close()
         jdbrowser.current_page = new_page
         jdbrowser.main_window.setCentralWidget(new_page)

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -331,6 +331,19 @@ class JdIdPage(QtWidgets.QWidget):
     def ascend_level(self):
         from .jd_area_page import JdAreaPage
         new_page = JdAreaPage()
+        # Highlight the area we were viewing in the parent page
+        target_tag_id = self.parent_uuid
+        found = False
+        for s, sec in enumerate(new_page.sections):
+            for i, item in enumerate(sec):
+                if item.tag_id == target_tag_id:
+                    new_page.sec_idx = s
+                    new_page.idx_in_sec = i
+                    found = True
+                    break
+            if found:
+                break
+        new_page.updateSelection()
         self.conn.close()
         jdbrowser.current_page = new_page
         jdbrowser.main_window.setCentralWidget(new_page)


### PR DESCRIPTION
## Summary
- Preserve selection when returning from directory list to extension view
- Highlight previously viewed extension in ID view
- Highlight previously viewed ID in area view

## Testing
- `pytest -q` *(fails: pyenv version `jdbrowser` not installed, pytest command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689843a91498832cab2657273338c4ee