### PR TITLE
Add padding to directory names on directory list page

### DIFF
--- a/jdbrowser/directory_item.py
+++ b/jdbrowser/directory_item.py
@@ -67,7 +67,8 @@ class DirectoryItem(QtWidgets.QWidget):
         font.setPointSize(int(font.pointSize() * 1.2))
         font.setBold(True)
         self.label.setFont(font)
-        self.label.setStyleSheet(f"color: {TEXT_COLOR};")
+        # Add a small padding so the text isn't flush against the edges
+        self.label.setStyleSheet(f"color: {TEXT_COLOR}; padding: 2px;")
         right_layout.addWidget(self.label)
         right_layout.addStretch(1)
         layout.addWidget(self.right)


### PR DESCRIPTION
## Summary
- add a small padding so directory names aren't flush against edges

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68984e0f67bc832c81126fca3bc77327