### PR TITLE
Use global ordering for directory lists

### DIFF
--- a/jdbrowser/database.py
+++ b/jdbrowser/database.py
@@ -334,7 +334,7 @@ def setup_database(db_path):
             parent_uuid TEXT,
             [order] INTEGER NOT NULL,
             label TEXT NOT NULL,
-            UNIQUE(parent_uuid, [order])
+            UNIQUE([order])
         );
 
         -- Indexes to accelerate lookups by parent_uuid
@@ -782,8 +782,8 @@ def create_jd_directory_tag(conn, parent_uuid, order, label):
     """Create a new directory tag and return its tag_id, or None on conflict."""
     cursor = conn.cursor()
     cursor.execute(
-        'SELECT tag_id FROM state_jd_directory_tags WHERE parent_uuid IS ? AND [order] = ?',
-        (parent_uuid, order),
+        'SELECT tag_id FROM state_jd_directory_tags WHERE [order] = ?',
+        (order,),
     )
     if cursor.fetchone():
         return None

--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -228,10 +228,7 @@ class JdDirectoryListPage(QtWidgets.QWidget):
 
     def _add_directory(self):
         cursor = self.conn.cursor()
-        cursor.execute(
-            "SELECT MAX([order]) FROM state_jd_directory_tags WHERE parent_uuid IS ?",
-            (self.parent_uuid,),
-        )
+        cursor.execute("SELECT MAX([order]) FROM state_jd_directory_tags")
         result = cursor.fetchone()
         max_order = result[0] if result and result[0] is not None else 0
         new_order = max_order + 1
@@ -268,8 +265,8 @@ class JdDirectoryListPage(QtWidgets.QWidget):
                 new_label = dialog.get_label()
                 new_icon_data = dialog.get_icon_data()
                 cursor.execute(
-                    "SELECT tag_id FROM state_jd_directory_tags WHERE parent_uuid IS ? AND [order] = ? AND tag_id != ?",
-                    (self.parent_uuid, new_order, tag_id),
+                    "SELECT tag_id FROM state_jd_directory_tags WHERE [order] = ? AND tag_id != ?",
+                    (new_order, tag_id),
                 )
                 if cursor.fetchone():
                     self._warn(


### PR DESCRIPTION
## Summary
- Order new directory tags using the highest order across all directories
- Prevent duplicate directory orders when editing tags
- Enforce global uniqueness of directory tag order in the database

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `python3 -m pip install pytest --break-system-packages` *(fails: Could not connect to proxy)*
- `python3 -m py_compile jdbrowser/jd_directory_list_page.py jdbrowser/database.py`


------
https://chatgpt.com/codex/tasks/task_e_6898516b485c832c82a562b264a14e37