### PR TITLE
Persist Tab toggle state across pages

### DIFF
--- a/jdbrowser/directory_item.py
+++ b/jdbrowser/directory_item.py
@@ -83,8 +83,8 @@ class DirectoryItem(QtWidgets.QWidget):
 
         self.updateStyle()
 
-    def updateLabel(self, show_path):
-        if show_path:
+    def updateLabel(self, show_prefix):
+        if show_prefix:
             formatted = f"{self.order:016d}"
             formatted = "_".join(formatted[i:i+4] for i in range(0, 16, 4))
             text = os.path.join(self.page.repository_path, formatted)

--- a/jdbrowser/jd_area_page.py
+++ b/jdbrowser/jd_area_page.py
@@ -45,8 +45,9 @@ class JdAreaPage(QtWidgets.QWidget):
         self.shortcuts = []
         self.search_shortcut_instances = []
         self.show_prefix = False
-        # Load show_hidden state from QSettings
+        # Load show_prefix and show_hidden state from QSettings
         settings = QtCore.QSettings("xAI", "jdbrowser")
+        self.show_prefix = settings.value("show_prefix", False, type=bool)
         self.show_hidden = settings.value("show_hidden", False, type=bool)
 
         # Initialize SQLite database
@@ -766,6 +767,8 @@ class JdAreaPage(QtWidgets.QWidget):
             for item in sec:
                 item.updateLabel(self.show_prefix)
         self.updateSelection()
+        settings = QtCore.QSettings("xAI", "jdbrowser")
+        settings.setValue("show_prefix", self.show_prefix)
 
     def _setup_shortcuts(self):
         self.setFocusPolicy(QtCore.Qt.FocusPolicy.StrongFocus)

--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -42,9 +42,9 @@ class JdDirectoryListPage(QtWidgets.QWidget):
 
         self.items = []
         self.selected_index = None
-        self.show_path = False
+        self.show_prefix = False
         settings = QtCore.QSettings("xAI", "jdbrowser")
-        self.show_path = settings.value("show_path", False, type=bool)
+        self.show_prefix = settings.value("show_prefix", False, type=bool)
         self.repository_path = read_config()
 
         self._setup_ui()
@@ -189,7 +189,7 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         for idx, row in enumerate(rows):
             tag_id, label, order, icon_data = row
             item = DirectoryItem(tag_id, label, order, icon_data, self, idx)
-            item.updateLabel(self.show_path)
+            item.updateLabel(self.show_prefix)
             self.vlayout.addWidget(item)
             self.items.append(item)
         self.vlayout.addStretch(1)
@@ -309,14 +309,14 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             else:
                 break
 
-    def toggle_directory_path(self):
-        self.show_path = not self.show_path
+    def toggle_label_prefix(self):
+        self.show_prefix = not self.show_prefix
         for item in self.items:
-            item.updateLabel(self.show_path)
+            item.updateLabel(self.show_prefix)
         if self.selected_index is not None:
             self.set_selection(self.selected_index)
         settings = QtCore.QSettings("xAI", "jdbrowser")
-        settings.setValue("show_path", self.show_path)
+        settings.setValue("show_prefix", self.show_prefix)
 
     def closeEvent(self, event):
         self.conn.close()
@@ -352,7 +352,7 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             ),
             (QtCore.Qt.Key_A, self._add_directory, None),
             (QtCore.Qt.Key_C, self._edit_tag_label_with_icon, None),
-            (QtCore.Qt.Key_Tab, self.toggle_directory_path, None),
+            (QtCore.Qt.Key_Tab, self.toggle_label_prefix, None),
         ]
         self.shortcuts = []
         for mapping in mappings:

--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -43,6 +43,8 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         self.items = []
         self.selected_index = None
         self.show_path = False
+        settings = QtCore.QSettings("xAI", "jdbrowser")
+        self.show_path = settings.value("show_path", False, type=bool)
         self.repository_path = read_config()
 
         self._setup_ui()
@@ -313,6 +315,8 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             item.updateLabel(self.show_path)
         if self.selected_index is not None:
             self.set_selection(self.selected_index)
+        settings = QtCore.QSettings("xAI", "jdbrowser")
+        settings.setValue("show_path", self.show_path)
 
     def closeEvent(self, event):
         self.conn.close()

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -45,8 +45,9 @@ class JdExtPage(QtWidgets.QWidget):
         self.shortcuts = []
         self.search_shortcut_instances = []
         self.show_prefix = False
-        # Load show_hidden state from QSettings
+        # Load show_prefix and show_hidden state from QSettings
         settings = QtCore.QSettings("xAI", "jdbrowser")
+        self.show_prefix = settings.value("show_prefix", False, type=bool)
         self.show_hidden = settings.value("show_hidden", False, type=bool)
 
         # Initialize SQLite database
@@ -854,6 +855,8 @@ class JdExtPage(QtWidgets.QWidget):
             for item in sec:
                 item.updateLabel(self.show_prefix)
         self.updateSelection()
+        settings = QtCore.QSettings("xAI", "jdbrowser")
+        settings.setValue("show_prefix", self.show_prefix)
 
     def _setup_shortcuts(self):
         self.setFocusPolicy(QtCore.Qt.FocusPolicy.StrongFocus)

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -44,8 +44,9 @@ class JdIdPage(QtWidgets.QWidget):
         self.shortcuts = []
         self.search_shortcut_instances = []
         self.show_prefix = False
-        # Load show_hidden state from QSettings
+        # Load show_prefix and show_hidden state from QSettings
         settings = QtCore.QSettings("xAI", "jdbrowser")
+        self.show_prefix = settings.value("show_prefix", False, type=bool)
         self.show_hidden = settings.value("show_hidden", False, type=bool)
 
         # Initialize SQLite database
@@ -809,6 +810,8 @@ class JdIdPage(QtWidgets.QWidget):
             for item in sec:
                 item.updateLabel(self.show_prefix)
         self.updateSelection()
+        settings = QtCore.QSettings("xAI", "jdbrowser")
+        settings.setValue("show_prefix", self.show_prefix)
 
     def _setup_shortcuts(self):
         self.setFocusPolicy(QtCore.Qt.FocusPolicy.StrongFocus)


### PR DESCRIPTION
## Summary
- Remember show_path state in directory list pages via QSettings and persist when Tab toggles directory paths.
- Load and save show_prefix state across area, id, and extension pages so Tab toggling sticks between navigations.

## Testing
- `python3 -m py_compile jdbrowser/jd_directory_list_page.py jdbrowser/jd_id_page.py jdbrowser/jd_area_page.py jdbrowser/jd_ext_page.py`
- `python3 -m pytest` *(fails: No module named pytest)*
- `pip install pytest` *(fails: externally-managed-environment)*

------
https://chatgpt.com/codex/tasks/task_e_68985358dc0c832c9f4d6614cd300d79