### PR TITLE
Guard scroll area scrollbar policy timers

### DIFF
--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -599,15 +599,16 @@ class JdExtPage(QtWidgets.QWidget):
             self.scroll_area.setWidgetResizable(True)
             self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
             self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+            scroll_area_ref = QtCore.QPointer(self.scroll_area)
             QtCore.QTimer.singleShot(
                 100,
-                lambda: self.scroll_area.setVerticalScrollBarPolicy(
+                lambda sa=scroll_area_ref: sa and sa.setVerticalScrollBarPolicy(
                     QtCore.Qt.ScrollBarAsNeeded
                 ),
             )
             QtCore.QTimer.singleShot(
                 100,
-                lambda: self.scroll_area.setHorizontalScrollBarPolicy(
+                lambda sa=scroll_area_ref: sa and sa.setHorizontalScrollBarPolicy(
                     QtCore.Qt.ScrollBarAsNeeded
                 ),
             )


### PR DESCRIPTION
## Summary
- prevent timers from running on deleted scroll areas by using QPointer references

## Testing
- `python3 -m py_compile jdbrowser/jd_ext_page.py`
- `python3 -m pytest` *(fails: No module named pytest; installation attempt failed: Could not find a version that satisfies the requirement pytest)*

------
https://chatgpt.com/codex/tasks/task_e_689858999bac832c860fd53356ec7265