### PR TITLE
Guard scroll area scrollbar policy timers

### DIFF
--- a/jdbrowser/jd_area_page.py
+++ b/jdbrowser/jd_area_page.py
@@ -1,6 +1,7 @@
 import os
 from collections import defaultdict
 from PySide6 import QtWidgets, QtGui, QtCore
+import shiboken6
 import jdbrowser
 from .dialogs import EditTagDialog, SimpleEditTagDialog, InputTagDialog, DeleteTagDialog
 from .dialogs.header_dialog import HeaderDialog
@@ -544,17 +545,16 @@ class JdAreaPage(QtWidgets.QWidget):
             self.scroll_area.setWidgetResizable(True)
             self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
             self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+            scroll_area = self.scroll_area
             QtCore.QTimer.singleShot(
                 100,
-                lambda: self.scroll_area.setVerticalScrollBarPolicy(
-                    QtCore.Qt.ScrollBarAsNeeded
-                ),
+                lambda sa=scroll_area: shiboken6.isValid(sa)
+                and sa.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded),
             )
             QtCore.QTimer.singleShot(
                 100,
-                lambda: self.scroll_area.setHorizontalScrollBarPolicy(
-                    QtCore.Qt.ScrollBarAsNeeded
-                ),
+                lambda sa=scroll_area: shiboken6.isValid(sa)
+                and sa.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded),
             )
             layout = QtWidgets.QVBoxLayout(self)
             layout.setContentsMargins(0, 0, 0, 0)

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -1,6 +1,7 @@
 import os
 from collections import defaultdict
 from PySide6 import QtWidgets, QtGui, QtCore
+import shiboken6
 import jdbrowser
 from .dialogs import EditTagDialog, SimpleEditTagDialog, InputTagDialog, DeleteTagDialog
 from .dialogs.header_dialog import HeaderDialog
@@ -599,17 +600,16 @@ class JdExtPage(QtWidgets.QWidget):
             self.scroll_area.setWidgetResizable(True)
             self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
             self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+            scroll_area = self.scroll_area
             QtCore.QTimer.singleShot(
                 100,
-                lambda: self.scroll_area.setVerticalScrollBarPolicy(
-                    QtCore.Qt.ScrollBarAsNeeded
-                ),
+                lambda sa=scroll_area: shiboken6.isValid(sa)
+                and sa.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded),
             )
             QtCore.QTimer.singleShot(
                 100,
-                lambda: self.scroll_area.setHorizontalScrollBarPolicy(
-                    QtCore.Qt.ScrollBarAsNeeded
-                ),
+                lambda sa=scroll_area: shiboken6.isValid(sa)
+                and sa.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded),
             )
             layout = QtWidgets.QVBoxLayout(self)
             layout.setContentsMargins(0, 0, 0, 0)

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -1,6 +1,7 @@
 import os
 from collections import defaultdict
 from PySide6 import QtWidgets, QtGui, QtCore
+import shiboken6
 import jdbrowser
 from .dialogs import EditTagDialog, SimpleEditTagDialog, InputTagDialog, DeleteTagDialog
 from .dialogs.header_dialog import HeaderDialog
@@ -580,17 +581,16 @@ class JdIdPage(QtWidgets.QWidget):
             self.scroll_area.setWidgetResizable(True)
             self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
             self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+            scroll_area = self.scroll_area
             QtCore.QTimer.singleShot(
                 100,
-                lambda: self.scroll_area.setVerticalScrollBarPolicy(
-                    QtCore.Qt.ScrollBarAsNeeded
-                ),
+                lambda sa=scroll_area: shiboken6.isValid(sa)
+                and sa.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded),
             )
             QtCore.QTimer.singleShot(
                 100,
-                lambda: self.scroll_area.setHorizontalScrollBarPolicy(
-                    QtCore.Qt.ScrollBarAsNeeded
-                ),
+                lambda sa=scroll_area: shiboken6.isValid(sa)
+                and sa.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded),
             )
             layout = QtWidgets.QVBoxLayout(self)
             layout.setContentsMargins(0, 0, 0, 0)


### PR DESCRIPTION
## Summary
- import shiboken6 and validate scroll area before adjusting scrollbar policies to avoid operating on deleted widgets

## Testing
- `python3 -m py_compile jdbrowser/jd_ext_page.py`
- `python3 -m pytest` *(fails: No module named pytest)*
- `python3 -m pip install pytest --break-system-packages` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_689858999bac832c860fd53356ec7265