### PR TITLE
Fix crash when opening tags

### DIFF
--- a/jdbrowser/__init__.py
+++ b/jdbrowser/__init__.py
@@ -1,8 +1,19 @@
 __version__ = "1.0.0"
 
+import os
+
+from .database import setup_database
+
 # Global pointer to the main application window.
 main_window = None
 
 # Global pointer to the currently displayed page widget.
 # This can hold a JdAreaPage, JdIdPage, JdExtPage or JdDirectoryListPage.
 current_page = None
+
+# Shared database connection used throughout the application.
+xdg_data_home = os.getenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share"))
+db_dir = os.path.join(xdg_data_home, "jdbrowser")
+os.makedirs(db_dir, exist_ok=True)
+db_path = os.path.join(db_dir, "tag.db")
+conn = setup_database(db_path)

--- a/jdbrowser/jd_area_page.py
+++ b/jdbrowser/jd_area_page.py
@@ -12,7 +12,6 @@ from .database import (
     create_jd_area_tag,
     delete_jd_area_tag,
     rebuild_state_jd_area_tags,
-    setup_database,
     create_jd_area_header,
     update_jd_area_header,
     delete_jd_area_header,
@@ -51,12 +50,8 @@ class JdAreaPage(QtWidgets.QWidget):
         self.show_prefix = settings.value("show_prefix", False, type=bool)
         self.show_hidden = settings.value("show_hidden", False, type=bool)
 
-        # Initialize SQLite database
-        xdg_data_home = os.getenv('XDG_DATA_HOME', os.path.expanduser('~/.local/share'))
-        db_dir = os.path.join(xdg_data_home, 'jdbrowser')
-        os.makedirs(db_dir, exist_ok=True)
-        self.db_path = os.path.join(db_dir, 'tag.db')
-        self.conn = setup_database(self.db_path)
+        # Shared SQLite database connection
+        self.conn = jdbrowser.conn
 
         app = QtWidgets.QApplication.instance()
         if app:
@@ -1145,7 +1140,6 @@ class JdAreaPage(QtWidgets.QWidget):
 
         # Instantiate the next level page and replace the current widget
         new_page = JdIdPage(parent_uuid=current_item.tag_id, jd_area=current_item.jd_area)
-        self.conn.close()
         jdbrowser.current_page = new_page
         jdbrowser.main_window.setCentralWidget(new_page)
 
@@ -1164,7 +1158,6 @@ class JdAreaPage(QtWidgets.QWidget):
         super().mousePressEvent(event)
 
     def closeEvent(self, event):
-        self.conn.close()
         super().closeEvent(event)
 
     def keyPressEvent(self, event):

--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -102,8 +102,11 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             if found:
                 break
         new_page.updateSelection()
+        self.conn.close()
         jdbrowser.current_page = new_page
-        jdbrowser.main_window.setCentralWidget(new_page)
+        QtCore.QTimer.singleShot(
+            0, lambda np=new_page: jdbrowser.main_window.setCentralWidget(np)
+        )
 
     def ascend_to_id(self):
         from .jd_id_page import JdIdPage
@@ -123,8 +126,11 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             if found:
                 break
         new_page.updateSelection()
+        self.conn.close()
         jdbrowser.current_page = new_page
-        jdbrowser.main_window.setCentralWidget(new_page)
+        QtCore.QTimer.singleShot(
+            0, lambda np=new_page: jdbrowser.main_window.setCentralWidget(np)
+        )
 
     def ascend_to_area(self):
         from .jd_area_page import JdAreaPage
@@ -142,8 +148,11 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             if found:
                 break
         new_page.updateSelection()
+        self.conn.close()
         jdbrowser.current_page = new_page
-        jdbrowser.main_window.setCentralWidget(new_page)
+        QtCore.QTimer.singleShot(
+            0, lambda np=new_page: jdbrowser.main_window.setCentralWidget(np)
+        )
 
     def _warn(self, title: str, message: str) -> None:
         box = QtWidgets.QMessageBox(self)
@@ -416,8 +425,11 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             grandparent_uuid=parent_uuid,
             great_grandparent_uuid=self.parent_uuid,
         )
+        self.conn.close()
         jdbrowser.current_page = new_page
-        jdbrowser.main_window.setCentralWidget(new_page)
+        QtCore.QTimer.singleShot(
+            0, lambda np=new_page: jdbrowser.main_window.setCentralWidget(np)
+        )
 
     def set_selection(self, index):
         if not (0 <= index < len(self.items)):

--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -76,19 +76,25 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         self._setup_shortcuts()
 
     def _navigate_to(self, new_page):
-        if self._navigating:
-            return
-        self._navigating = True
+        """Swap in *new_page* on the next event loop iteration.
+
+        The current page is deleted after the swap to avoid use-after-free
+        issues if navigation is triggered while event handlers are still
+        running.
+        """
+        old_page = self
 
         def swap():
             jdbrowser.main_window.setCentralWidget(new_page)
             jdbrowser.current_page = new_page
+            old_page.deleteLater()
 
         QtCore.QTimer.singleShot(0, swap)
 
     def ascend_level(self):
         if self._navigating:
             return
+        self._navigating = True
         from .jd_ext_page import JdExtPage
 
         new_page = JdExtPage(
@@ -115,6 +121,7 @@ class JdDirectoryListPage(QtWidgets.QWidget):
     def ascend_to_id(self):
         if self._navigating:
             return
+        self._navigating = True
         from .jd_id_page import JdIdPage
 
         new_page = JdIdPage(
@@ -137,6 +144,7 @@ class JdDirectoryListPage(QtWidgets.QWidget):
     def ascend_to_area(self):
         if self._navigating:
             return
+        self._navigating = True
         from .jd_area_page import JdAreaPage
 
         new_page = JdAreaPage()
@@ -413,6 +421,7 @@ class JdDirectoryListPage(QtWidgets.QWidget):
     def open_tag(self, tag_id, order, parent_uuid):
         if self._navigating:
             return
+        self._navigating = True
         from .jd_directory_list_page import JdDirectoryListPage
 
         s = f"{order:016d}"

--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -81,10 +81,22 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         self._setup_ui()
         self._setup_shortcuts()
 
-    def ascend_level(self):
+    def _navigate_to(self, new_page):
         if self._navigating:
             return
         self._navigating = True
+
+        def swap():
+            jdbrowser.main_window.setCentralWidget(new_page)
+            jdbrowser.current_page = new_page
+            self.conn.close()
+            self.deleteLater()
+
+        QtCore.QTimer.singleShot(0, swap)
+
+    def ascend_level(self):
+        if self._navigating:
+            return
         from .jd_ext_page import JdExtPage
 
         new_page = JdExtPage(
@@ -106,16 +118,11 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             if found:
                 break
         new_page.updateSelection()
-        self.conn.close()
-        jdbrowser.current_page = new_page
-        QtCore.QTimer.singleShot(
-            0, lambda np=new_page: jdbrowser.main_window.setCentralWidget(np)
-        )
+        self._navigate_to(new_page)
 
     def ascend_to_id(self):
         if self._navigating:
             return
-        self._navigating = True
         from .jd_id_page import JdIdPage
 
         new_page = JdIdPage(
@@ -133,16 +140,11 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             if found:
                 break
         new_page.updateSelection()
-        self.conn.close()
-        jdbrowser.current_page = new_page
-        QtCore.QTimer.singleShot(
-            0, lambda np=new_page: jdbrowser.main_window.setCentralWidget(np)
-        )
+        self._navigate_to(new_page)
 
     def ascend_to_area(self):
         if self._navigating:
             return
-        self._navigating = True
         from .jd_area_page import JdAreaPage
 
         new_page = JdAreaPage()
@@ -158,11 +160,7 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             if found:
                 break
         new_page.updateSelection()
-        self.conn.close()
-        jdbrowser.current_page = new_page
-        QtCore.QTimer.singleShot(
-            0, lambda np=new_page: jdbrowser.main_window.setCentralWidget(np)
-        )
+        self._navigate_to(new_page)
 
     def _warn(self, title: str, message: str) -> None:
         box = QtWidgets.QMessageBox(self)
@@ -423,7 +421,6 @@ class JdDirectoryListPage(QtWidgets.QWidget):
     def open_tag(self, tag_id, order, parent_uuid):
         if self._navigating:
             return
-        self._navigating = True
         from .jd_directory_list_page import JdDirectoryListPage
 
         s = f"{order:016d}"
@@ -438,11 +435,7 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             grandparent_uuid=parent_uuid,
             great_grandparent_uuid=self.parent_uuid,
         )
-        self.conn.close()
-        jdbrowser.current_page = new_page
-        QtCore.QTimer.singleShot(
-            0, lambda np=new_page: jdbrowser.main_window.setCentralWidget(np)
-        )
+        self._navigate_to(new_page)
 
     def set_selection(self, index):
         if not (0 <= index < len(self.items)):

--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -76,11 +76,15 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         self.current_match_idx = -1
         self.shortcuts = []
         self.search_shortcut_instances = []
+        self._navigating = False
 
         self._setup_ui()
         self._setup_shortcuts()
 
     def ascend_level(self):
+        if self._navigating:
+            return
+        self._navigating = True
         from .jd_ext_page import JdExtPage
 
         new_page = JdExtPage(
@@ -109,6 +113,9 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         )
 
     def ascend_to_id(self):
+        if self._navigating:
+            return
+        self._navigating = True
         from .jd_id_page import JdIdPage
 
         new_page = JdIdPage(
@@ -133,6 +140,9 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         )
 
     def ascend_to_area(self):
+        if self._navigating:
+            return
+        self._navigating = True
         from .jd_area_page import JdAreaPage
 
         new_page = JdAreaPage()
@@ -411,6 +421,9 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         self.vlayout.addStretch(1)
 
     def open_tag(self, tag_id, order, parent_uuid):
+        if self._navigating:
+            return
+        self._navigating = True
         from .jd_directory_list_page import JdDirectoryListPage
 
         s = f"{order:016d}"

--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -87,10 +87,13 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         self._navigating = True
 
         def swap():
+            # Close the database connection before the old page is replaced.
+            # QMainWindow takes ownership of the current central widget and
+            # deletes it when a new one is set, so we avoid touching `self`
+            # after calling setCentralWidget to prevent use-after-free errors.
+            self.conn.close()
             jdbrowser.main_window.setCentralWidget(new_page)
             jdbrowser.current_page = new_page
-            self.conn.close()
-            self.deleteLater()
 
         QtCore.QTimer.singleShot(0, swap)
 

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -12,7 +12,6 @@ from .database import (
     create_jd_ext_tag,
     delete_jd_ext_tag,
     rebuild_state_jd_ext_tags,
-    setup_database,
     create_jd_ext_header,
     update_jd_ext_header,
     delete_jd_ext_header,
@@ -51,12 +50,8 @@ class JdExtPage(QtWidgets.QWidget):
         self.show_prefix = settings.value("show_prefix", False, type=bool)
         self.show_hidden = settings.value("show_hidden", False, type=bool)
 
-        # Initialize SQLite database
-        xdg_data_home = os.getenv('XDG_DATA_HOME', os.path.expanduser('~/.local/share'))
-        db_dir = os.path.join(xdg_data_home, 'jdbrowser')
-        os.makedirs(db_dir, exist_ok=True)
-        self.db_path = os.path.join(db_dir, 'tag.db')
-        self.conn = setup_database(self.db_path)
+        # Shared SQLite database connection
+        self.conn = jdbrowser.conn
 
         cursor = self.conn.cursor()
         cursor.execute(
@@ -366,7 +361,6 @@ class JdExtPage(QtWidgets.QWidget):
             if found:
                 break
         new_page.updateSelection()
-        self.conn.close()
         jdbrowser.current_page = new_page
         jdbrowser.main_window.setCentralWidget(new_page)
 
@@ -386,7 +380,6 @@ class JdExtPage(QtWidgets.QWidget):
             if found:
                 break
         new_page.updateSelection()
-        self.conn.close()
         jdbrowser.current_page = new_page
         jdbrowser.main_window.setCentralWidget(new_page)
 
@@ -1248,7 +1241,6 @@ class JdExtPage(QtWidgets.QWidget):
             grandparent_uuid=self.parent_uuid,
             great_grandparent_uuid=self.grandparent_uuid,
         )
-        self.conn.close()
         jdbrowser.current_page = new_page
         jdbrowser.main_window.setCentralWidget(new_page)
 
@@ -1267,7 +1259,6 @@ class JdExtPage(QtWidgets.QWidget):
         super().mousePressEvent(event)
 
     def closeEvent(self, event):
-        self.conn.close()
         super().closeEvent(event)
 
     def keyPressEvent(self, event):

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -11,7 +11,6 @@ from .search_line_edit import SearchLineEdit
 from .database import (
     create_jd_id_tag,
     rebuild_state_jd_id_tags,
-    setup_database,
     create_jd_id_header,
     update_jd_id_header,
     delete_jd_id_header,
@@ -50,12 +49,8 @@ class JdIdPage(QtWidgets.QWidget):
         self.show_prefix = settings.value("show_prefix", False, type=bool)
         self.show_hidden = settings.value("show_hidden", False, type=bool)
 
-        # Initialize SQLite database
-        xdg_data_home = os.getenv('XDG_DATA_HOME', os.path.expanduser('~/.local/share'))
-        db_dir = os.path.join(xdg_data_home, 'jdbrowser')
-        os.makedirs(db_dir, exist_ok=True)
-        self.db_path = os.path.join(db_dir, 'tag.db')
-        self.conn = setup_database(self.db_path)
+        # Shared SQLite database connection
+        self.conn = jdbrowser.conn
 
         cursor = self.conn.cursor()
         cursor.execute(
@@ -354,7 +349,6 @@ class JdIdPage(QtWidgets.QWidget):
             if found:
                 break
         new_page.updateSelection()
-        self.conn.close()
         jdbrowser.current_page = new_page
         jdbrowser.main_window.setCentralWidget(new_page)
 
@@ -1195,7 +1189,6 @@ class JdIdPage(QtWidgets.QWidget):
             jd_id=current_item.jd_id,
             grandparent_uuid=self.parent_uuid,
         )
-        self.conn.close()
         jdbrowser.current_page = new_page
         jdbrowser.main_window.setCentralWidget(new_page)
 
@@ -1214,7 +1207,6 @@ class JdIdPage(QtWidgets.QWidget):
         super().mousePressEvent(event)
 
     def closeEvent(self, event):
-        self.conn.close()
         super().closeEvent(event)
 
     def keyPressEvent(self, event):


### PR DESCRIPTION
## Summary
- defer central widget swaps to avoid deleting active page during tag navigation
- close database connection when leaving JdDirectoryListPage

## Testing
- `python -m py_compile jdbrowser/jd_directory_list_page.py`
- `pip install pytest` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68987dac6514832cbc886641935d84c1