### PR TITLE
Reuse single database connection across pages

### DIFF
--- a/jdbrowser/database.py
+++ b/jdbrowser/database.py
@@ -1,8 +1,18 @@
 import sqlite3
 import uuid
 
+_shared_connection = None
+
+
 def setup_database(db_path):
-    """Initialize SQLite database tables with triggers and state constraints."""
+    """Initialize SQLite database tables with triggers and state constraints.
+
+    A single SQLite connection is reused across the application so that all
+    pages share the same database handle.
+    """
+    global _shared_connection
+    if _shared_connection is not None:
+        return _shared_connection
     conn = sqlite3.connect(db_path)
     conn.execute('PRAGMA foreign_keys = ON')
     cursor = conn.cursor()
@@ -387,7 +397,8 @@ def setup_database(db_path):
     rebuild_state_jd_ext_headers(conn)
     rebuild_state_jd_directory_tags(conn)
     conn.commit()
-    return conn
+    _shared_connection = conn
+    return _shared_connection
 
 def rebuild_state_jd_area_tags(conn):
     """Rebuild the state_jd_area_tags table from the event log."""

--- a/jdbrowser/jd_area_page.py
+++ b/jdbrowser/jd_area_page.py
@@ -1145,7 +1145,6 @@ class JdAreaPage(QtWidgets.QWidget):
 
         # Instantiate the next level page and replace the current widget
         new_page = JdIdPage(parent_uuid=current_item.tag_id, jd_area=current_item.jd_area)
-        self.conn.close()
         jdbrowser.current_page = new_page
         jdbrowser.main_window.setCentralWidget(new_page)
 
@@ -1162,10 +1161,6 @@ class JdAreaPage(QtWidgets.QWidget):
         if self.in_search_mode:
             self.exit_search_mode_select()
         super().mousePressEvent(event)
-
-    def closeEvent(self, event):
-        self.conn.close()
-        super().closeEvent(event)
 
     def keyPressEvent(self, event):
         super().keyPressEvent(event)

--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -667,10 +667,6 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             self.exit_search_mode_select()
         super().mousePressEvent(event)
 
-    def closeEvent(self, event):
-        self.conn.close()
-        super().closeEvent(event)
-
     def resizeEvent(self, event):
         self.search_input.move(self.width() - 310, self.height() - 40)
         super().resizeEvent(event)

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -366,7 +366,6 @@ class JdExtPage(QtWidgets.QWidget):
             if found:
                 break
         new_page.updateSelection()
-        self.conn.close()
         jdbrowser.current_page = new_page
         jdbrowser.main_window.setCentralWidget(new_page)
 
@@ -386,7 +385,6 @@ class JdExtPage(QtWidgets.QWidget):
             if found:
                 break
         new_page.updateSelection()
-        self.conn.close()
         jdbrowser.current_page = new_page
         jdbrowser.main_window.setCentralWidget(new_page)
 
@@ -1248,7 +1246,6 @@ class JdExtPage(QtWidgets.QWidget):
             grandparent_uuid=self.parent_uuid,
             great_grandparent_uuid=self.grandparent_uuid,
         )
-        self.conn.close()
         jdbrowser.current_page = new_page
         jdbrowser.main_window.setCentralWidget(new_page)
 
@@ -1265,10 +1262,6 @@ class JdExtPage(QtWidgets.QWidget):
         if self.in_search_mode:
             self.exit_search_mode_select()
         super().mousePressEvent(event)
-
-    def closeEvent(self, event):
-        self.conn.close()
-        super().closeEvent(event)
 
     def keyPressEvent(self, event):
         super().keyPressEvent(event)

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -354,7 +354,6 @@ class JdIdPage(QtWidgets.QWidget):
             if found:
                 break
         new_page.updateSelection()
-        self.conn.close()
         jdbrowser.current_page = new_page
         jdbrowser.main_window.setCentralWidget(new_page)
 
@@ -1195,7 +1194,6 @@ class JdIdPage(QtWidgets.QWidget):
             jd_id=current_item.jd_id,
             grandparent_uuid=self.parent_uuid,
         )
-        self.conn.close()
         jdbrowser.current_page = new_page
         jdbrowser.main_window.setCentralWidget(new_page)
 
@@ -1212,10 +1210,6 @@ class JdIdPage(QtWidgets.QWidget):
         if self.in_search_mode:
             self.exit_search_mode_select()
         super().mousePressEvent(event)
-
-    def closeEvent(self, event):
-        self.conn.close()
-        super().closeEvent(event)
 
     def keyPressEvent(self, event):
         super().keyPressEvent(event)


### PR DESCRIPTION
## Summary
- Reuse a single SQLite connection instead of opening one per page
- Ensure the shared connection remains open by removing page-level `close()` calls

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_689889a83450832cae09535aa0e04ca6