### PR TITLE
Disable tag pill navigation in directory list page

### DIFF
--- a/jdbrowser/directory_item.py
+++ b/jdbrowser/directory_item.py
@@ -128,9 +128,6 @@ class DirectoryItem(QtWidgets.QWidget):
                 " border-radius: 10px; padding: 3px 7px;"
             )
             btn.setMinimumWidth(60)
-            btn.clicked.connect(
-                lambda checked=False, tid=t_id, o=t_order, p=parent_uuid: self.page.open_tag(tid, o, p)
-            )
             self.tag_buttons.append((btn, t_id, t_label, t_order, parent_uuid))
             self.tags_layout.addWidget(btn)
         self.tags_widget.adjustSize()

--- a/jdbrowser/directory_item.py
+++ b/jdbrowser/directory_item.py
@@ -128,6 +128,11 @@ class DirectoryItem(QtWidgets.QWidget):
                 " border-radius: 10px; padding: 3px 7px;"
             )
             btn.setMinimumWidth(60)
+            # Pass mouse events through to the DirectoryItem so clicking a tag
+            # pill still selects the underlying directory entry
+            btn.mousePressEvent = self.mousePressEvent  # type: ignore[attr-defined]
+            btn.enterEvent = self.enterEvent  # type: ignore[attr-defined]
+            btn.leaveEvent = self.leaveEvent  # type: ignore[attr-defined]
             self.tag_buttons.append((btn, t_id, t_label, t_order, parent_uuid))
             self.tags_layout.addWidget(btn)
         self.tags_widget.adjustSize()

--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -401,24 +401,6 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             self.items.append(item)
         self.vlayout.addStretch(1)
 
-    def open_tag(self, tag_id, order, parent_uuid):
-        from .jd_directory_list_page import JdDirectoryListPage
-
-        s = f"{order:016d}"
-        area = int(s[0:4])
-        jd_id = int(s[4:8])
-        jd_ext = int(s[8:12])
-        new_page = JdDirectoryListPage(
-            parent_uuid=tag_id,
-            jd_area=area,
-            jd_id=jd_id,
-            jd_ext=jd_ext,
-            grandparent_uuid=parent_uuid,
-            great_grandparent_uuid=self.parent_uuid,
-        )
-        jdbrowser.current_page = new_page
-        jdbrowser.main_window.setCentralWidget(new_page)
-
     def set_selection(self, index):
         if not (0 <= index < len(self.items)):
             return


### PR DESCRIPTION
## Summary
- Stop tag pills from triggering navigation in `DirectoryItem`
- Remove `open_tag` handler from `JdDirectoryListPage`

## Testing
- `python -m pytest` *(fails: No module named pytest)*
- `python -m unittest` *(fails: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_68988d46bfdc832cbb702852ff88959d