### PR TITLE
Add fuzzy tag search overlay for directories

### DIFF
--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -684,6 +684,12 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             return
         current_item = self.items[self.selected_index]
         cursor = self.conn.cursor()
+        cursor.execute(
+            "SELECT 1 FROM state_jd_directory_tags WHERE parent_uuid = ? AND LOWER(label) = LOWER(?)",
+            (current_item.tag_id, label),
+        )
+        if cursor.fetchone():
+            return
         cursor.execute("SELECT MAX([order]) FROM state_jd_directory_tags")
         row = cursor.fetchone()
         max_order = row[0] if row and row[0] is not None else 0

--- a/jdbrowser/tag_search_overlay.py
+++ b/jdbrowser/tag_search_overlay.py
@@ -14,6 +14,8 @@ class TagSearchOverlay(QtWidgets.QFrame):
         self.conn = conn
         self.setFrameShape(QtWidgets.QFrame.NoFrame)
         self.setFixedWidth(600)
+        self.setAttribute(QtCore.Qt.WA_TranslucentBackground)
+        self.setStyleSheet("background: transparent;")
 
         self._input_style_core = (
             f"background-color: {BACKGROUND_COLOR};"
@@ -68,7 +70,7 @@ class TagSearchOverlay(QtWidgets.QFrame):
         layout.addWidget(self.list)
 
         self.item_height = QtGui.QFontMetrics(QtGui.QFont("FiraCode Nerd Font", 18)).height() + 16
-        self.max_results = 5
+        self.max_results = 6
 
         self.all_labels = []
         self.label_map = {}
@@ -119,6 +121,7 @@ class TagSearchOverlay(QtWidgets.QFrame):
         else:
             self.list.hide()
             self.input.setStyleSheet(self.input_style_no_results)
+        self.adjustSize()
 
     def move_selection(self, delta):
         count = self.list.count()
@@ -141,11 +144,15 @@ class TagSearchOverlay(QtWidgets.QFrame):
         if obj is self.input and event.type() == QtCore.QEvent.KeyPress:
             key = event.key()
             mods = event.modifiers()
-            if key in (QtCore.Qt.Key_Down, QtCore.Qt.Key_J, QtCore.Qt.Key_Tab) and not (mods & QtCore.Qt.ShiftModifier):
+            if (
+                key in (QtCore.Qt.Key_Down, QtCore.Qt.Key_Tab) and not (mods & QtCore.Qt.ShiftModifier)
+            ) or (key == QtCore.Qt.Key_J and mods & QtCore.Qt.ControlModifier):
                 self.move_selection(1)
                 return True
-            if key in (QtCore.Qt.Key_Up, QtCore.Qt.Key_K, QtCore.Qt.Key_Backtab) or (
-                key == QtCore.Qt.Key_Tab and mods & QtCore.Qt.ShiftModifier
+            if (
+                key in (QtCore.Qt.Key_Up, QtCore.Qt.Key_Backtab)
+                or (key == QtCore.Qt.Key_Tab and mods & QtCore.Qt.ShiftModifier)
+                or (key == QtCore.Qt.Key_K and mods & QtCore.Qt.ControlModifier)
             ):
                 self.move_selection(-1)
                 return True

--- a/jdbrowser/tag_search_overlay.py
+++ b/jdbrowser/tag_search_overlay.py
@@ -1,6 +1,11 @@
 from difflib import get_close_matches
 from PySide6 import QtWidgets, QtCore, QtGui
-from .constants import BACKGROUND_COLOR, TEXT_COLOR, BORDER_COLOR, HIGHLIGHT_COLOR
+from .constants import (
+    TEXT_COLOR,
+    TAG_COLOR,
+    BREADCRUMB_BG_COLOR,
+    BREADCRUMB_ACTIVE_COLOR,
+)
 
 
 class TagSearchOverlay(QtWidgets.QFrame):
@@ -18,9 +23,9 @@ class TagSearchOverlay(QtWidgets.QFrame):
         self.setStyleSheet("background: transparent;")
 
         self._input_style_core = (
-            f"background-color: {BACKGROUND_COLOR};"
+            f"background-color: {TAG_COLOR};"
             f" color: {TEXT_COLOR};"
-            f" border: 1px solid {BORDER_COLOR};"
+            f" border: 2px solid {BREADCRUMB_BG_COLOR};"
             " border-top-left-radius: 10px;"
             " border-top-right-radius: 10px;"
             " padding: 12px;"
@@ -28,17 +33,21 @@ class TagSearchOverlay(QtWidgets.QFrame):
             " font-size: 24px;"
         )
         self.input_style_no_results = (
-            "QLineEdit {" + self._input_style_core + " border-bottom-left-radius: 10px; border-bottom-right-radius: 10px;}"
+            "QLineEdit {"
+            + self._input_style_core
+            + " border-bottom-left-radius: 10px; border-bottom-right-radius: 10px;}"
         )
         self.input_style_with_results = (
-            "QLineEdit {" + self._input_style_core + " border-bottom: none;}"
+            "QLineEdit {"
+            + self._input_style_core
+            + " border-bottom: none; border-bottom-left-radius: 0; border-bottom-right-radius: 0;}"
         )
 
         self.list_style = f"""
             QListWidget {{
-                background-color: {BACKGROUND_COLOR};
+                background-color: {TAG_COLOR};
                 color: {TEXT_COLOR};
-                border: 1px solid {BORDER_COLOR};
+                border: 2px solid {BREADCRUMB_BG_COLOR};
                 border-top: none;
                 border-bottom-left-radius: 10px;
                 border-bottom-right-radius: 10px;
@@ -50,8 +59,8 @@ class TagSearchOverlay(QtWidgets.QFrame):
                 padding: 8px 4px;
             }}
             QListWidget::item:selected {{
-                background-color: {HIGHLIGHT_COLOR};
-                color: {TEXT_COLOR};
+                background-color: {BREADCRUMB_BG_COLOR};
+                color: {BREADCRUMB_ACTIVE_COLOR};
             }}
         """
         layout = QtWidgets.QVBoxLayout(self)

--- a/jdbrowser/tag_search_overlay.py
+++ b/jdbrowser/tag_search_overlay.py
@@ -1,0 +1,139 @@
+from difflib import get_close_matches
+from PySide6 import QtWidgets, QtCore
+from .constants import BACKGROUND_COLOR, TEXT_COLOR, BORDER_COLOR, HIGHLIGHT_COLOR
+
+
+class TagSearchOverlay(QtWidgets.QFrame):
+    """Overlay search box with fuzzy find for tag labels."""
+
+    tagSelected = QtCore.Signal(str)
+    closed = QtCore.Signal()
+
+    def __init__(self, parent, conn):
+        super().__init__(parent)
+        self.conn = conn
+        self.setFrameShape(QtWidgets.QFrame.StyledPanel)
+        self.setStyleSheet(
+            f"""
+            QFrame {{
+                background-color: {BACKGROUND_COLOR};
+                border: 1px solid {BORDER_COLOR};
+                border-radius: 5px;
+            }}
+            QLineEdit {{
+                background-color: {BACKGROUND_COLOR};
+                color: {TEXT_COLOR};
+                border: none;
+                padding: 6px;
+                font-family: 'FiraCode Nerd Font';
+            }}
+            QListWidget {{
+                background-color: {BACKGROUND_COLOR};
+                color: {TEXT_COLOR};
+                border-top: 1px solid {BORDER_COLOR};
+                outline: none;
+                font-family: 'FiraCode Nerd Font';
+            }}
+            QListWidget::item:selected {{
+                background-color: {HIGHLIGHT_COLOR};
+                color: {TEXT_COLOR};
+            }}
+            """
+        )
+        self.setFixedWidth(500)
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        self.input = QtWidgets.QLineEdit()
+        layout.addWidget(self.input)
+        self.list = QtWidgets.QListWidget()
+        self.list.setFixedHeight(6 * 30)
+        layout.addWidget(self.list)
+
+        self.all_labels = []
+        self.label_map = {}
+
+        self.input.textChanged.connect(self.update_results)
+        self.input.installEventFilter(self)
+
+    def open(self):
+        self._load_labels()
+        self.input.clear()
+        self.update_results("")
+        self.reposition()
+        self.show()
+        self.input.setFocus()
+
+    def reposition(self):
+        parent = self.parent()
+        if parent:
+            x = (parent.width() - self.width()) // 2
+            y = 80
+            self.move(x, y)
+
+    def _load_labels(self):
+        cursor = self.conn.cursor()
+        cursor.execute(
+            """
+            SELECT label FROM state_jd_area_tags
+            UNION
+            SELECT label FROM state_jd_id_tags
+            UNION
+            SELECT label FROM state_jd_ext_tags
+            UNION
+            SELECT label FROM state_jd_directory_tags
+            """
+        )
+        labels = [r[0] for r in cursor.fetchall() if r[0]]
+        self.label_map = {lbl.lower(): lbl for lbl in sorted(set(labels), key=lambda s: s.lower())}
+        self.all_labels = list(self.label_map.keys())
+
+    def update_results(self, text):
+        if text:
+            matches_lower = get_close_matches(text.lower(), self.all_labels, n=6, cutoff=0)
+            results = [self.label_map[m] for m in matches_lower]
+        else:
+            results = list(self.label_map.values())[:6]
+        self.list.clear()
+        for label in results:
+            self.list.addItem(label)
+        if results:
+            self.list.setCurrentRow(0)
+
+    def move_selection(self, delta):
+        count = self.list.count()
+        if count == 0:
+            return
+        row = (self.list.currentRow() + delta) % count
+        self.list.setCurrentRow(row)
+
+    def select_current(self):
+        item = self.list.currentItem()
+        if item:
+            self.tagSelected.emit(item.text())
+        self.close_overlay()
+
+    def close_overlay(self):
+        self.hide()
+        self.closed.emit()
+
+    def eventFilter(self, obj, event):
+        if obj is self.input and event.type() == QtCore.QEvent.KeyPress:
+            key = event.key()
+            mods = event.modifiers()
+            if key in (QtCore.Qt.Key_Down, QtCore.Qt.Key_J, QtCore.Qt.Key_Tab) and not (mods & QtCore.Qt.ShiftModifier):
+                self.move_selection(1)
+                return True
+            if key in (QtCore.Qt.Key_Up, QtCore.Qt.Key_K, QtCore.Qt.Key_Backtab) or (
+                key == QtCore.Qt.Key_Tab and mods & QtCore.Qt.ShiftModifier
+            ):
+                self.move_selection(-1)
+                return True
+            if key in (QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter):
+                self.select_current()
+                return True
+            if key == QtCore.Qt.Key_Escape:
+                self.close_overlay()
+                return True
+        return super().eventFilter(obj, event)

--- a/jdbrowser/tag_search_overlay.py
+++ b/jdbrowser/tag_search_overlay.py
@@ -3,8 +3,9 @@ from PySide6 import QtWidgets, QtCore, QtGui
 from .constants import (
     TEXT_COLOR,
     TAG_COLOR,
-    BREADCRUMB_BG_COLOR,
-    BREADCRUMB_ACTIVE_COLOR,
+    HIGHLIGHT_COLOR,
+    HOVER_COLOR,
+    SLATE_COLOR,
 )
 
 
@@ -23,9 +24,9 @@ class TagSearchOverlay(QtWidgets.QFrame):
         self.setStyleSheet("background: transparent;")
 
         self._input_style_core = (
-            f"background-color: {TAG_COLOR};"
+            f"background-color: {SLATE_COLOR};"
             f" color: {TEXT_COLOR};"
-            f" border: 2px solid {BREADCRUMB_BG_COLOR};"
+            f" border: 2px solid {HIGHLIGHT_COLOR};"
             " border-top-left-radius: 10px;"
             " border-top-right-radius: 10px;"
             " padding: 12px;"
@@ -45,9 +46,9 @@ class TagSearchOverlay(QtWidgets.QFrame):
 
         self.list_style = f"""
             QListWidget {{
-                background-color: {TAG_COLOR};
+                background-color: {SLATE_COLOR};
                 color: {TEXT_COLOR};
-                border: 2px solid {BREADCRUMB_BG_COLOR};
+                border: 2px solid {HIGHLIGHT_COLOR};
                 border-top: none;
                 border-bottom-left-radius: 10px;
                 border-bottom-right-radius: 10px;
@@ -58,9 +59,12 @@ class TagSearchOverlay(QtWidgets.QFrame):
             QListWidget::item {{
                 padding: 8px 4px;
             }}
+            QListWidget::item:hover {{
+                background-color: {HOVER_COLOR};
+            }}
             QListWidget::item:selected {{
-                background-color: {BREADCRUMB_BG_COLOR};
-                color: {BREADCRUMB_ACTIVE_COLOR};
+                background-color: {TAG_COLOR};
+                color: {TEXT_COLOR};
             }}
         """
         layout = QtWidgets.QVBoxLayout(self)
@@ -76,10 +80,11 @@ class TagSearchOverlay(QtWidgets.QFrame):
         self.list.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
         self.list.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
         self.list.hide()
+        self.list.itemClicked.connect(self._item_clicked)
         layout.addWidget(self.list)
 
         self.item_height = QtGui.QFontMetrics(QtGui.QFont("FiraCode Nerd Font", 18)).height() + 16
-        self.max_results = 6
+        self.max_results = 5
 
         self.all_labels = []
         self.label_map = {}
@@ -141,6 +146,11 @@ class TagSearchOverlay(QtWidgets.QFrame):
 
     def select_current(self):
         item = self.list.currentItem()
+        if item:
+            self.tagSelected.emit(item.text())
+        self.close_overlay()
+
+    def _item_clicked(self, item):
         if item:
             self.tagSelected.emit(item.text())
         self.close_overlay()


### PR DESCRIPTION
## Summary
- Overlay tag search box triggered with **e** for quick tagging
- Fuzzy search over existing tags with keyboard navigation and TokyoNight styling
- Selected result applies tag to current directory

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_6898f7a8b0b8832cab85a09f6095d86a