### PR TITLE
Rename directory tag functions and tables

### DIFF
--- a/jdbrowser/directory_item.py
+++ b/jdbrowser/directory_item.py
@@ -12,9 +12,11 @@ from .flow_layout import FlowLayout
 
 
 class DirectoryItem(QtWidgets.QWidget):
-    def __init__(self, tag_id, label, order, icon_data, page, index, tags=None):
+    def __init__(
+        self, directory_id, label, order, icon_data, page, index, tags=None
+    ):
         super().__init__()
-        self.tag_id = tag_id
+        self.directory_id = directory_id
         self.label_text = label if label is not None else ""
         self.order = order
         # Each tag tuple: (tag_id, label, order, parent_uuid)
@@ -191,7 +193,7 @@ class DirectoryItem(QtWidgets.QWidget):
         return super().eventFilter(watched, event)
 
     def mousePressEvent(self, event):
-        """Select on left-click; right-click edits the tag."""
+        """Select on left-click; right-click edits the directory."""
         if self.page:
             if event.button() == QtCore.Qt.LeftButton:
                 self.page.set_selection(self.index)


### PR DESCRIPTION
## Summary
- rename directory-tag events and tables to directory counterparts
- use directory_id in event and state tables
- update UI to use new directory helpers

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68990f44e9a0832ca0570aeaf00b577a