### PR TITLE
Shorter directory names in prefix mode

### DIFF
--- a/jdbrowser/directory_item.py
+++ b/jdbrowser/directory_item.py
@@ -201,7 +201,7 @@ class DirectoryItem(QtWidgets.QWidget):
         if show_prefix:
             formatted = f"{self.order:016d}"
             formatted = "_".join(formatted[i:i+4] for i in range(0, 16, 4))
-            text = os.path.join(self.page.repository_path, formatted)
+            text = formatted
         else:
             text = self.label_text
         self.label.setText(text)

--- a/jdbrowser/recent_directory_item.py
+++ b/jdbrowser/recent_directory_item.py
@@ -79,7 +79,7 @@ class RecentDirectoryItem(QtWidgets.QWidget):
             formatted = "_".join(
                 formatted[i : i + 4] for i in range(0, 16, 4)
             )
-            text = os.path.join(self.page.repository_path, formatted)
+            text = formatted
         else:
             text = self.label_text
         self.label.setText(text)


### PR DESCRIPTION
## Summary
- Trim directory labels in prefix mode to the 16-digit order string without repo path

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689936ba9950832cad36aa93c3c89eeb