### PR TITLE
Allow removing directory tag with confirmation

### DIFF
--- a/jdbrowser/dialogs/__init__.py
+++ b/jdbrowser/dialogs/__init__.py
@@ -2,3 +2,4 @@ from .edit_tag_dialog import EditTagDialog
 from .simple_edit_tag_dialog import SimpleEditTagDialog
 from .input_tag_dialog import InputTagDialog
 from .delete_tag_dialog import DeleteTagDialog
+from .remove_directory_tag_dialog import RemoveDirectoryTagDialog

--- a/jdbrowser/dialogs/remove_directory_tag_dialog.py
+++ b/jdbrowser/dialogs/remove_directory_tag_dialog.py
@@ -1,0 +1,42 @@
+from PySide6 import QtWidgets
+from ..constants import *
+
+class RemoveDirectoryTagDialog(QtWidgets.QDialog):
+    def __init__(self, directory_name, tag_name, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Confirm Remove")
+        self.setFixedWidth(600)
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setSpacing(10)
+        layout.setContentsMargins(10, 10, 10, 10)
+
+        message = (
+            f"Are you sure you want to remove the tag '{tag_name}' from the directory '{directory_name}'?"
+        )
+        self.message = QtWidgets.QLabel(message)
+        self.message.setStyleSheet(f"color: {TEXT_COLOR};")
+        layout.addWidget(self.message)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
+        )
+        buttons.setStyleSheet(
+            f"""
+            QPushButton {{
+                background-color: {BUTTON_COLOR};
+                color: black;
+                border: none;
+                padding: 5px;
+                border-radius: 5px;
+            }}
+            QPushButton:hover {{
+                background-color: #e0c58f;
+            }}
+            """
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self.setStyleSheet(f"background-color: {BACKGROUND_COLOR};")
+

--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -9,9 +9,10 @@ from .database import (
     rebuild_state_jd_directories,
     create_jd_directory,
     add_directory_tag,
+    remove_directory_tag,
     rebuild_state_directory_tags,
 )
-from .dialogs import EditTagDialog, SimpleEditTagDialog
+from .dialogs import EditTagDialog, SimpleEditTagDialog, RemoveDirectoryTagDialog
 from .constants import *
 from .config import read_config
 from .search_line_edit import SearchLineEdit
@@ -626,6 +627,25 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             else:
                 break
 
+    def _remove_tag_from_directory(self):
+        """Remove the current jd_ext tag from the selected directory."""
+        if self.selected_index is None or not (0 <= self.selected_index < len(self.items)):
+            return
+        current_item = self.items[self.selected_index]
+        directory_id = current_item.directory_id
+        dialog = RemoveDirectoryTagDialog(current_item.label_text, self.ext_label, self)
+        if dialog.exec() == QtWidgets.QDialog.Accepted:
+            remove_directory_tag(self.conn, directory_id, self.parent_uuid)
+            rebuild_state_directory_tags(self.conn)
+            idx = self.selected_index
+            self._load_directories()
+            if self.items:
+                if idx is None or idx >= len(self.items):
+                    idx = len(self.items) - 1
+                self.set_selection(idx)
+            else:
+                self.selected_index = None
+
     def enter_search_mode(self):
         if not self.in_search_mode:
             if not self.items:
@@ -805,6 +825,7 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             (QtCore.Qt.Key_C, self._edit_tag_label_with_icon, None),
             (QtCore.Qt.Key_R, self._rename_tag_label, None),
             (QtCore.Qt.Key_F2, self._rename_tag_label, None),
+            (QtCore.Qt.Key_D, self._remove_tag_from_directory, None),
             (QtCore.Qt.Key_E, self.open_tag_search, None),
             (QtCore.Qt.Key_Tab, self.toggle_label_prefix, None),
             (QtCore.Qt.Key_Slash, self.enter_search_mode, None),


### PR DESCRIPTION
## Summary
- add a dialog to confirm removing a tag from a directory
- allow pressing `d` on a directory to remove the current tag after confirmation

## Testing
- `python3 -m py_compile jdbrowser/jd_directory_list_page.py jdbrowser/dialogs/remove_directory_tag_dialog.py jdbrowser/dialogs/__init__.py`
- `python3 -m pip install pytest` *(fails: externally-managed-environment)*
- `python3 -m pytest -q` *(fails: No module named pytest)*


------
https://chatgpt.com/codex/tasks/task_e_6899388c35f4832caa6abedaa5d527aa