### PR TITLE
Add untagged directories section

### DIFF
--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -86,6 +86,9 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         self.recent_items = []
         self.recent_wrapper = None
         self.recent_frame = None
+        self.untagged_items = []
+        self.untagged_wrapper = None
+        self.untagged_frame = None
 
         self._setup_ui()
         self._setup_shortcuts()
@@ -372,6 +375,9 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         self.recent_items = []
         self.recent_wrapper = None
         self.recent_frame = None
+        self.untagged_items = []
+        self.untagged_wrapper = None
+        self.untagged_frame = None
 
     def _load_directories(self):
         self._clear_items()
@@ -414,6 +420,7 @@ class JdDirectoryListPage(QtWidgets.QWidget):
             self.vlayout.addWidget(item)
             self.items.append(item)
         self._load_recent_directories()
+        self._load_untagged_directories()
         self.vlayout.addStretch(1)
 
     def _load_recent_directories(self):
@@ -470,10 +477,63 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         )
         QtCore.QTimer.singleShot(0, self._update_recent_width)
 
+    def _load_untagged_directories(self):
+        cursor = self.conn.cursor()
+        cursor.execute(
+            """
+            SELECT e.directory_id, d.label, d.[order], i.icon
+            FROM event_create_jd_directory e
+            JOIN state_jd_directories d ON e.directory_id = d.directory_id
+            LEFT JOIN state_jd_directory_icons i ON d.directory_id = i.directory_id
+            LEFT JOIN state_jd_directory_tags t ON d.directory_id = t.directory_id
+            WHERE t.directory_id IS NULL
+            ORDER BY e.event_id DESC
+            LIMIT 5
+            """
+        )
+        rows = cursor.fetchall()
+        if not rows:
+            return
+        self.untagged_items = []
+        self.untagged_wrapper = QtWidgets.QWidget()
+        outer_layout = QtWidgets.QVBoxLayout(self.untagged_wrapper)
+        outer_layout.setContentsMargins(0, 0, 0, 0)
+        outer_layout.setSpacing(5)
+
+        title = QtWidgets.QLabel("Untagged Directories")
+        title_font = title.font()
+        title_font.setPointSize(int(title_font.pointSize() * 0.9))
+        title.setFont(title_font)
+        title.setStyleSheet(f"color: {BREADCRUMB_INACTIVE_COLOR};")
+        outer_layout.addWidget(title, alignment=QtCore.Qt.AlignmentFlag.AlignHCenter)
+
+        self.untagged_frame = QtWidgets.QFrame()
+        self.untagged_frame.setStyleSheet(
+            f"border: 1px solid {BORDER_COLOR}; border-radius: 8px;" f" background-color: #000;"
+        )
+        self.untagged_frame.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred
+        )
+        v_layout = QtWidgets.QVBoxLayout(self.untagged_frame)
+        v_layout.setContentsMargins(10, 10, 10, 10)
+        v_layout.setSpacing(5)
+        for directory_id, label, order, icon_data in rows:
+            item = RecentDirectoryItem(directory_id, label, order, icon_data, self)
+            item.updateLabel(self.show_prefix)
+            v_layout.addWidget(item)
+            self.untagged_items.append(item)
+        outer_layout.addWidget(self.untagged_frame)
+        self.vlayout.addWidget(
+            self.untagged_wrapper, alignment=QtCore.Qt.AlignmentFlag.AlignHCenter
+        )
+        QtCore.QTimer.singleShot(0, self._update_recent_width)
+
     def _update_recent_width(self):
+        width = int(self.width() * 0.6)
         if self.recent_wrapper:
-            width = int(self.width() * 0.6)
             self.recent_wrapper.setFixedWidth(width)
+        if self.untagged_wrapper:
+            self.untagged_wrapper.setFixedWidth(width)
 
     def set_selection(self, index):
         if not (0 <= index < len(self.items)):
@@ -736,6 +796,8 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         for item in self.items:
             item.updateLabel(self.show_prefix)
         for item in self.recent_items:
+            item.updateLabel(self.show_prefix)
+        for item in self.untagged_items:
             item.updateLabel(self.show_prefix)
         if self.selected_index is not None:
             self.set_selection(self.selected_index)


### PR DESCRIPTION
## Summary
- Add "Untagged Directories" section to `JdDirectoryListPage` showing five directories without tags
- Track untagged directory widgets and adjust width handling and label prefix toggling

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `venv/bin/pip install pytest -q` *(fails: Could not find a version that satisfies the requirement pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68993bbbd9f4832c986e7bc06e05ae76