### PR TITLE
Enable navigation into recent and untagged directory sections

### DIFF
--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -460,10 +460,7 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         outer_layout.addWidget(title, alignment=QtCore.Qt.AlignmentFlag.AlignHCenter)
 
         self.recent_frame = QtWidgets.QFrame()
-        self.recent_frame.setStyleSheet(
-            f"border: 1px solid {BORDER_COLOR}; border-radius: 8px;"
-            f" background-color: #000;"
-        )
+        self.recent_frame.setStyleSheet("background-color: #000; border: none;")
         self.recent_frame.setSizePolicy(
             QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred
         )
@@ -533,9 +530,7 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         outer_layout.addWidget(title, alignment=QtCore.Qt.AlignmentFlag.AlignHCenter)
 
         self.untagged_frame = QtWidgets.QFrame()
-        self.untagged_frame.setStyleSheet(
-            f"border: 1px solid {BORDER_COLOR}; border-radius: 8px;" f" background-color: #000;"
-        )
+        self.untagged_frame.setStyleSheet("background-color: #000; border: none;")
         self.untagged_frame.setSizePolicy(
             QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred
         )

--- a/jdbrowser/recent_directory_item.py
+++ b/jdbrowser/recent_directory_item.py
@@ -6,7 +6,6 @@ from .constants import (
     BREADCRUMB_ACTIVE_COLOR,
     HIGHLIGHT_COLOR,
     HOVER_COLOR,
-    TEXT_COLOR,
 )
 from .flow_layout import FlowLayout
 
@@ -151,7 +150,7 @@ class RecentDirectoryItem(QtWidgets.QWidget):
             btn = QtWidgets.QPushButton(t_label)
             btn.setCursor(QtGui.QCursor(QtCore.Qt.CursorShape.PointingHandCursor))
             btn.setStyleSheet(
-                f"background-color: {BREADCRUMB_INACTIVE_COLOR}; color: {TEXT_COLOR}; border: none;"
+                f"background-color: {HIGHLIGHT_COLOR}; color: {BREADCRUMB_ACTIVE_COLOR}; border: none;"
                 " border-radius: 10px; padding: 3px 7px;"
             )
             btn.setMinimumWidth(60)

--- a/jdbrowser/recent_directory_item.py
+++ b/jdbrowser/recent_directory_item.py
@@ -3,20 +3,23 @@ from PySide6 import QtWidgets, QtGui, QtCore
 from .constants import (
     SLATE_COLOR,
     BREADCRUMB_INACTIVE_COLOR,
+    BREADCRUMB_ACTIVE_COLOR,
     HIGHLIGHT_COLOR,
     HOVER_COLOR,
+    TEXT_COLOR,
 )
+from .flow_layout import FlowLayout
 
 
 class RecentDirectoryItem(QtWidgets.QWidget):
-    def __init__(self, directory_id, label, order, icon_data, page, index):
+    def __init__(self, directory_id, label, order, icon_data, page, index, tags=None):
         super().__init__()
         self.directory_id = directory_id
         self.label_text = label if label is not None else ""
         self.order = order
         self.page = page
         self.index = index
-        self.tags = []
+        self.tags = tags or []
         self.isSelected = False
         self.isHover = False
         self.isDimmed = False
@@ -69,25 +72,37 @@ class RecentDirectoryItem(QtWidgets.QWidget):
             )
         layout.addWidget(self.icon)
 
+        self.right = QtWidgets.QWidget()
+        right_layout = QtWidgets.QVBoxLayout(self.right)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+        right_layout.setSpacing(2)
+
         self.label = QtWidgets.QLabel(self.label_text)
         self.label.setAlignment(
-            QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter
+            QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignTop
         )
         font = self.label.font()
         font.setPointSize(int(font.pointSize() * 0.9))
         self.label.setFont(font)
-        self.label.setStyleSheet(
-            f"color: {BREADCRUMB_INACTIVE_COLOR}; padding-left: 5px; border: none;"
-        )
-        self.label.setSizePolicy(
-            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred
-        )
-        layout.addWidget(self.label, 1)
+        self.label.setStyleSheet("padding-left: 5px; border: none;")
+        right_layout.addWidget(self.label)
 
-        for widget in (self.icon, self.label):
+        self.tags_widget = QtWidgets.QWidget()
+        self.tags_widget.setSizePolicy(
+            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Minimum
+        )
+        self.tags_layout = FlowLayout(self.tags_widget, margin=0, spacing=5)
+        self.tags_layout.setContentsMargins(5, 2, 0, 0)
+        right_layout.addWidget(self.tags_widget)
+        right_layout.addStretch(1)
+
+        layout.addWidget(self.right, 1)
+
+        for widget in (self.icon, self.right, self.label, self.tags_widget):
             widget.mousePressEvent = self.mousePressEvent  # type: ignore[attr-defined]
             widget.installEventFilter(self)
 
+        self._build_tag_pills()
         self.updateStyle()
 
     def updateLabel(self, show_prefix):
@@ -107,6 +122,11 @@ class RecentDirectoryItem(QtWidgets.QWidget):
             if self.isSelected
             else (HOVER_COLOR if self.isHover else "transparent")
         )
+        fg = (
+            BREADCRUMB_ACTIVE_COLOR
+            if self.isSelected
+            else BREADCRUMB_INACTIVE_COLOR
+        )
         opacity = 0.4 if self.isDimmed else 1.0
         icon_effect = QtWidgets.QGraphicsOpacityEffect(self.icon)
         icon_effect.setOpacity(opacity)
@@ -114,7 +134,30 @@ class RecentDirectoryItem(QtWidgets.QWidget):
         label_effect = QtWidgets.QGraphicsOpacityEffect(self.label)
         label_effect.setOpacity(opacity)
         self.label.setGraphicsEffect(label_effect)
+        tags_effect = QtWidgets.QGraphicsOpacityEffect(self.tags_widget)
+        tags_effect.setOpacity(opacity)
+        self.tags_widget.setGraphicsEffect(tags_effect)
+        self.label.setStyleSheet(
+            f"color: {fg}; padding-left: 5px; border: none;"
+        )
         self.setStyleSheet(f"background-color: {bg}; border-radius: 3px;")
+
+    def _build_tag_pills(self):
+        while self.tags_layout.count():
+            item = self.tags_layout.takeAt(0)
+            if w := item.widget():
+                w.deleteLater()
+        for t_id, t_label, t_order, parent_uuid in self.tags:
+            btn = QtWidgets.QPushButton(t_label)
+            btn.setCursor(QtGui.QCursor(QtCore.Qt.CursorShape.PointingHandCursor))
+            btn.setStyleSheet(
+                f"background-color: {BREADCRUMB_INACTIVE_COLOR}; color: {TEXT_COLOR}; border: none;"
+                " border-radius: 10px; padding: 3px 7px;"
+            )
+            btn.setMinimumWidth(60)
+            btn.mousePressEvent = self.mousePressEvent  # type: ignore[attr-defined]
+            btn.installEventFilter(self)
+            self.tags_layout.addWidget(btn)
 
     def _on_enter(self):
         self.isHover = True


### PR DESCRIPTION
## Summary
- allow directory selection to move through Recent and Untagged sections
- add selection and hover handling to RecentDirectoryItem
- pressing `a` tags selected directory when in sub-sections

## Testing
- Attempted to run `pip install pytest` but it failed: see logs
- Attempted to run `/usr/bin/python3 -m pytest` but module not found


------
https://chatgpt.com/codex/tasks/task_e_68998148b8c4832cb331b320a86d0396