### PR TITLE
Ignore `d` in recent or untagged sections

### DIFF
--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -786,6 +786,10 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         if self.selected_index is None or not (0 <= self.selected_index < len(self.items)):
             return
         current_item = self.items[self.selected_index]
+        # Recent and untagged directories are guaranteed not to have the current
+        # tag, so pressing "d" on them should be a no-op.
+        if current_item in self.recent_items or current_item in self.untagged_items:
+            return
         directory_id = current_item.directory_id
         dialog = RemoveDirectoryTagDialog(current_item.label_text, self.ext_label, self)
         if dialog.exec() == QtWidgets.QDialog.Accepted:


### PR DESCRIPTION
## Summary
- Avoid removing tags when `d` is pressed on items in the Recent or Untagged directories sections

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68998b8c9ca0832cbbcb9bf06b031fa7