### PR TITLE
Add fuzzy tag removal for directories

### DIFF
--- a/jdbrowser/tag_search_overlay.py
+++ b/jdbrowser/tag_search_overlay.py
@@ -92,8 +92,11 @@ class TagSearchOverlay(QtWidgets.QFrame):
         self.input.textChanged.connect(self.update_results)
         self.input.installEventFilter(self)
 
-    def open(self):
-        self._load_labels()
+    def open(self, label_rows=None):
+        if label_rows is None:
+            self._load_labels()
+        else:
+            self._set_labels(label_rows)
         self.input.clear()
         self.update_results("")
         self.reposition()
@@ -111,6 +114,9 @@ class TagSearchOverlay(QtWidgets.QFrame):
         cursor = self.conn.cursor()
         cursor.execute("SELECT tag_id, label FROM state_jd_ext_tags")
         rows = [(r[0], r[1]) for r in cursor.fetchall() if r[1]]
+        self._set_labels(rows)
+
+    def _set_labels(self, rows):
         self.label_map = {
             lbl.lower(): (lbl, tag_id)
             for tag_id, lbl in sorted(rows, key=lambda s: s[1].lower())


### PR DESCRIPTION
## Summary
- Allow removing arbitrary tags from a directory via a fuzzy search opened with `x`
- Extend `TagSearchOverlay` to accept custom tag lists so it can display only tags on the selected directory

## Testing
- `python3 -m py_compile jdbrowser/tag_search_overlay.py jdbrowser/jd_directory_list_page.py`


------
https://chatgpt.com/codex/tasks/task_e_68998f6fd240832cbad8c9ebd006c4db