### PR TITLE
Darken page hover color

### DIFF
--- a/jdbrowser/constants.py
+++ b/jdbrowser/constants.py
@@ -1,6 +1,6 @@
 # TokyoNight Dark theme colors
 HIGHLIGHT_COLOR = '#44475a'
-HOVER_COLOR = '#5c6370'
+HOVER_COLOR = '#1a1b26'
 SLATE_COLOR = '#2e303e'
 # Dark placeholder thumbnail background and lighter font color for readability
 PLACEHOLDER_COLOR = '#1c1c1c'


### PR DESCRIPTION
## Summary
- darken mouse-hover color for page items to differentiate from selection

## Testing
- `python3 -m py_compile jdbrowser/constants.py`


------
https://chatgpt.com/codex/tasks/task_e_689990d88bc0832c8366cb7926ab2573