### PR TITLE
Expand directory info area

### DIFF
--- a/jdbrowser/directory_item.py
+++ b/jdbrowser/directory_item.py
@@ -28,6 +28,9 @@ class DirectoryItem(QtWidgets.QWidget):
         self.isHover = False
         self.isDimmed = False
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_Hover)
+        self.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+        )
 
         layout = QtWidgets.QHBoxLayout(self)
         layout.setContentsMargins(5, 5, 5, 5)
@@ -71,6 +74,9 @@ class DirectoryItem(QtWidgets.QWidget):
         layout.addWidget(self.icon)
 
         self.right = QtWidgets.QWidget()
+        self.right.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred
+        )
         right_layout = QtWidgets.QVBoxLayout(self.right)
         right_layout.setContentsMargins(0, 0, 0, 0)
         right_layout.setSpacing(5)
@@ -97,7 +103,7 @@ class DirectoryItem(QtWidgets.QWidget):
         right_layout.addWidget(self.tags_widget)
         right_layout.addStretch(1)
         self._build_tag_pills()
-        layout.addWidget(self.right)
+        layout.addWidget(self.right, 1)
 
         # Ensure clicks on child widgets behave like the parent item and
         # monitor their hover events via an event filter

--- a/jdbrowser/jd_directory_page.py
+++ b/jdbrowser/jd_directory_page.py
@@ -133,7 +133,10 @@ class JdDirectoryPage(QtWidgets.QWidget):
         self.item.updateLabel(self.show_prefix)
         self.item.isSelected = False
         self.item.updateStyle()
-        layout.addWidget(self.item, alignment=QtCore.Qt.AlignmentFlag.AlignLeft)
+        self.item.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+        )
+        layout.addWidget(self.item)
         layout.addStretch(1)
 
     def _strip_prefix(self, text: str) -> str:


### PR DESCRIPTION
## Summary
- let DirectoryItem request horizontal expansion and stretch its info panel
- allow JdDirectoryPage's directory entry to fill the full width

## Testing
- `python3 -m py_compile jdbrowser/directory_item.py jdbrowser/jd_directory_page.py`


------
https://chatgpt.com/codex/tasks/task_e_6899a4806b94832c9cb8b59dfcad34c2