### PR TITLE
Reduce vertical spacing between file entries

### DIFF
--- a/jdbrowser/jd_directory_page.py
+++ b/jdbrowser/jd_directory_page.py
@@ -179,7 +179,7 @@ class JdDirectoryPage(QtWidgets.QWidget):
             "QListWidget{background-color: transparent; border: none;}"
             "QListWidget::item{background-color: transparent; border: none;}"
         )
-        self.file_list.setSpacing(5)
+        self.file_list.setSpacing(2)
         layout.addWidget(self.file_list)
 
         self._populate_files(order)
@@ -213,7 +213,7 @@ class JdDirectoryPage(QtWidgets.QWidget):
         )
         row.setStyleSheet("background-color: transparent;")
         layout = QtWidgets.QHBoxLayout(row)
-        layout.setContentsMargins(0, 5, 0, 5)
+        layout.setContentsMargins(0, 2, 0, 2)
         layout.setSpacing(10)
 
         icon_label = QtWidgets.QLabel()


### PR DESCRIPTION
## Summary
- Halve vertical margins between file entries on `JdDirectoryPage` by tightening list spacing and row layout margins.

## Testing
- N/A

------
https://chatgpt.com/codex/tasks/task_e_6899b2a9829c832c8aac509fe713c7d4