### PR TITLE
Preserve selection color on JdDirectoryPage

### DIFF
--- a/jdbrowser/jd_directory_page.py
+++ b/jdbrowser/jd_directory_page.py
@@ -179,8 +179,9 @@ class JdDirectoryPage(QtWidgets.QWidget):
         self.file_list.setStyleSheet(
             "QListWidget{background-color: transparent; border: none;}"
             "QListWidget::item{background-color: transparent; border: none; border-radius: 5px;}"
-            f"QListWidget::item:selected{{background-color: {HIGHLIGHT_COLOR};}}"
             f"QListWidget::item:hover{{background-color: {HOVER_COLOR};}}"
+            f"QListWidget::item:selected{{background-color: {HIGHLIGHT_COLOR};}}"
+            f"QListWidget::item:selected:hover{{background-color: {HIGHLIGHT_COLOR};}}"
         )
         self.file_list.setSpacing(2)
         self.file_list.setSelectionMode(


### PR DESCRIPTION
## Summary
- keep file selection highlight when hovering files on JdDirectoryPage


------
https://chatgpt.com/codex/tasks/task_e_6899b764b9cc832c9baf673b0a3faeb8