### PR TITLE
Ensure directory selection clears file selection

### DIFF
--- a/jdbrowser/jd_directory_page.py
+++ b/jdbrowser/jd_directory_page.py
@@ -84,6 +84,10 @@ class JdDirectoryPage(QtWidgets.QWidget):
 
     # DirectoryItem expects a set_selection method on its page
     def set_selection(self, index):
+        if index == 0:
+            # Deselect any file items so only the directory entry is selected
+            self.file_list.setCurrentItem(None)
+            self.file_list.clearSelection()
         self.item.isSelected = index == 0
         self.item.updateStyle()
 


### PR DESCRIPTION
## Summary
- clear the file list selection when the directory entry is clicked so only one item is active at a time

## Testing
- `python3 -m py_compile jdbrowser/jd_directory_page.py`


------
https://chatgpt.com/codex/tasks/task_e_6899b8ec996c832cacf6cb46b114fc4b