### PR TITLE
Restrict directory editing shortcuts to directory selection

### DIFF
--- a/jdbrowser/jd_directory_page.py
+++ b/jdbrowser/jd_directory_page.py
@@ -387,6 +387,9 @@ class JdDirectoryPage(QtWidgets.QWidget):
         self.item.isSelected = current is None
         self.item.updateStyle()
 
+    def _is_directory_selected(self) -> bool:
+        return self.file_list.currentItem() is None
+
     def _setup_shortcuts(self):
         self.shortcuts = []
         self.setFocusPolicy(QtCore.Qt.FocusPolicy.StrongFocus)
@@ -583,6 +586,8 @@ class JdDirectoryPage(QtWidgets.QWidget):
         self.item.updateStyle()
 
     def _rename_tag_label(self):
+        if not self._is_directory_selected():
+            return
         cursor = self.conn.cursor()
         cursor.execute(
             "SELECT label FROM state_jd_directories WHERE directory_id = ?",
@@ -606,6 +611,8 @@ class JdDirectoryPage(QtWidgets.QWidget):
             self._refresh_item()
 
     def _edit_tag_label_with_icon(self):
+        if not self._is_directory_selected():
+            return
         cursor = self.conn.cursor()
         cursor.execute(
             "SELECT [order], label FROM state_jd_directories WHERE directory_id = ?",
@@ -667,6 +674,8 @@ class JdDirectoryPage(QtWidgets.QWidget):
                 break
 
     def open_tag_search(self):
+        if not self._is_directory_selected():
+            return
         if not self.tag_search_overlay:
             self.tag_search_overlay = TagSearchOverlay(self, self.conn)
             self.tag_search_overlay.tagSelected.connect(self.apply_tag_to_directory)
@@ -698,6 +707,8 @@ class JdDirectoryPage(QtWidgets.QWidget):
         self._refresh_item()
 
     def open_remove_tag_search(self):
+        if not self._is_directory_selected():
+            return
         cursor = self.conn.cursor()
         cursor.execute(
             """


### PR DESCRIPTION
## Summary
- Add `_is_directory_selected` helper to check whether the top directory entry is selected
- Guard directory-editing shortcuts (C, E, X, R, F2) so they act only when the directory entry is selected

## Testing
- `python3 -m py_compile jdbrowser/jd_directory_page.py`


------
https://chatgpt.com/codex/tasks/task_e_6899bb478b24832ca8223c98f891d2af