### PR TITLE
Add UNRA timestamp prefix shortcuts

### DIFF
--- a/jdbrowser/jd_directory_page.py
+++ b/jdbrowser/jd_directory_page.py
@@ -1060,7 +1060,10 @@ class JdDirectoryPage(QtWidgets.QWidget):
                 ext = rest
             new_name = f"[5-UNRA {ts_str}]" + ext
         else:
-            new_name = f"[5-UNRA {ts_str}] {rest}" if rest else f"[5-UNRA {ts_str}]"
+            if not rest or rest.startswith("."):
+                new_name = f"[5-UNRA {ts_str}]{rest}"
+            else:
+                new_name = f"[5-UNRA {ts_str}] {rest}"
         if new_name == name:
             return
         new_path = os.path.join(dir_path, new_name)


### PR DESCRIPTION
## Summary
- allow '=' and '-' keys to prepend or replace filenames with `[5-UNRA yyyy-MM-dd HH.MM.ss]`
- choose file creation time for '=' and current time for '-'

## Testing
- `python3 -m py_compile jdbrowser/jd_directory_page.py`


------
https://chatgpt.com/codex/tasks/task_e_6899d02f7b9c832c8f90a4321dd327e8