### PR TITLE
Add tilde shortcut for navigating home

### DIFF
--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -1087,6 +1087,7 @@ class JdDirectoryListPage(QtWidgets.QWidget):
                 None,
                 QtCore.Qt.KeyboardModifier.AltModifier,
             ),
+            (QtCore.Qt.Key_AsciiTilde, self.ascend_to_area, None),
             (QtCore.Qt.Key_A, self._add_directory, None),
             (QtCore.Qt.Key_C, self._edit_tag_label_with_icon, None),
             (QtCore.Qt.Key_R, self._rename_tag_label, None),

--- a/jdbrowser/jd_directory_page.py
+++ b/jdbrowser/jd_directory_page.py
@@ -932,6 +932,7 @@ class JdDirectoryPage(QtWidgets.QWidget):
                 None,
                 QtCore.Qt.KeyboardModifier.AltModifier,
             ),
+            (QtCore.Qt.Key_AsciiTilde, self.ascend_to_area, None),
             (QtCore.Qt.Key_J, self.move_selection, 1),
             (QtCore.Qt.Key_Down, self.move_selection, 1),
             (QtCore.Qt.Key_K, self.move_selection, -1),
@@ -1475,6 +1476,25 @@ class JdDirectoryPage(QtWidgets.QWidget):
         remove_directory_tag(self.conn, self.directory_id, tag_uuid)
         rebuild_state_directory_tags(self.conn)
         self._refresh_item()
+
+    def ascend_to_area(self):
+        from .jd_area_page import JdAreaPage
+
+        new_page = JdAreaPage()
+        target_tag_id = self.great_grandparent_uuid
+        found = False
+        for s, sec in enumerate(new_page.sections):
+            for i, item in enumerate(sec):
+                if item.tag_id == target_tag_id:
+                    new_page.sec_idx = s
+                    new_page.idx_in_sec = i
+                    found = True
+                    break
+            if found:
+                break
+        new_page.updateSelection()
+        jdbrowser.current_page = new_page
+        jdbrowser.main_window.setCentralWidget(new_page)
 
     def ascend_level(self):
         if self.parent_uuid is None:

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -983,6 +983,7 @@ class JdExtPage(QtWidgets.QWidget):
               (QtCore.Qt.Key_Enter, self.descend_level, None),
               (QtCore.Qt.Key_Backspace, self.ascend_level, None),
               (QtCore.Qt.Key_Up, self.ascend_level, None, QtCore.Qt.KeyboardModifier.AltModifier),
+              (QtCore.Qt.Key_AsciiTilde, self.ascend_to_area, None),
           ]
         quit_keys = ['Q', 'Ctrl+Q', 'Ctrl+W', 'Alt+F4']
         self.shortcuts = []

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -912,6 +912,7 @@ class JdIdPage(QtWidgets.QWidget):
               (QtCore.Qt.Key_Enter, self.descend_level, None),
               (QtCore.Qt.Key_Backspace, self.ascend_level, None),
               (QtCore.Qt.Key_Up, self.ascend_level, None, QtCore.Qt.KeyboardModifier.AltModifier),
+              (QtCore.Qt.Key_AsciiTilde, self.ascend_level, None),
           ]
         quit_keys = ['Q', 'Ctrl+Q', 'Ctrl+W', 'Alt+F4']
         self.shortcuts = []


### PR DESCRIPTION
## Summary
- Pressing `~` on any non-area page jumps back to `JdAreaPage`
- Enable home navigation from directory pages by adding `ascend_to_area`

## Testing
- `python3 -m py_compile jdbrowser/jd_ext_page.py jdbrowser/jd_directory_list_page.py jdbrowser/jd_id_page.py jdbrowser/jd_directory_page.py`


------
https://chatgpt.com/codex/tasks/task_e_689c052ef288832c8f6c76de7fb521ed