### PR TITLE
Fix relative markdown image paths in JdDirectoryPage

### DIFF
--- a/jdbrowser/jd_directory_page.py
+++ b/jdbrowser/jd_directory_page.py
@@ -619,6 +619,11 @@ class JdDirectoryPage(QtWidgets.QWidget):
         browser.setOpenExternalLinks(False)
         browser.setOpenLinks(False)
         browser.anchorClicked.connect(self._handle_anchor_click)
+        # Ensure that relative resources like images are resolved relative to
+        # the markdown file's directory rather than the process's working
+        # directory.
+        base_url = QtCore.QUrl.fromLocalFile(os.path.dirname(path) + "/")
+        browser.document().setBaseUrl(base_url)
         browser.setHtml(html)
         browser.setStyleSheet(
             f"color: {TEXT_COLOR}; background-color: transparent; border: none;"


### PR DESCRIPTION
## Summary
- Ensure markdown widgets resolve relative links against the markdown file's directory

## Testing
- `python3 -m py_compile jdbrowser/jd_directory_page.py`


------
https://chatgpt.com/codex/tasks/task_e_689cd2cd26a4832c8d6480e6931dc144