### PR TITLE
Enable smooth Markdown scrolling

### DIFF
--- a/jdbrowser/jd_directory_page.py
+++ b/jdbrowser/jd_directory_page.py
@@ -315,6 +315,9 @@ class JdDirectoryPage(QtWidgets.QWidget):
             f"QListWidget::item:selected:hover{{background-color: {HIGHLIGHT_COLOR};}}"
         )
         self.file_list.setSpacing(2)
+        self.file_list.setVerticalScrollMode(
+            QtWidgets.QAbstractItemView.ScrollPerPixel
+        )
         self.file_list.setSelectionMode(
             QtWidgets.QAbstractItemView.SingleSelection
         )


### PR DESCRIPTION
## Summary
- Use pixel-based scrolling in `JdDirectoryPage` so long Markdown sections remain visible while scrolling

## Testing
- `python3 -m py_compile jdbrowser/jd_directory_page.py`


------
https://chatgpt.com/codex/tasks/task_e_689cd5723110832c9a755f52f41ee7fe