### PR TITLE
Speed up vertical paging navigation

### DIFF
--- a/jdbrowser/jd_area_page.py
+++ b/jdbrowser/jd_area_page.py
@@ -965,7 +965,7 @@ class JdAreaPage(QtWidgets.QWidget):
                 self.desired_col = self.idx_in_sec % self.cols
             self.updateSelection()
 
-    def moveVert(self, direction):
+    def moveVert(self, direction, update=True):
         if not self.in_search_mode and self.sections:
             pref_col = self.desired_col
             sec_index = self.sec_idx
@@ -984,7 +984,8 @@ class JdAreaPage(QtWidgets.QWidget):
                     length = min(cols, len(sec2))
                     self.sec_idx += 1
                     self.idx_in_sec = min(pref_col, length - 1)
-                self.updateSelection()
+                if update:
+                    self.updateSelection()
             else:
                 if row > 0:
                     r2 = row - 1
@@ -997,7 +998,8 @@ class JdAreaPage(QtWidgets.QWidget):
                     length = min(cols, len(sec2) - last * cols)
                     self.sec_idx -= 1
                     self.idx_in_sec = last * cols + min(pref_col, length - 1)
-                self.updateSelection()
+                if update:
+                    self.updateSelection()
 
     def moveToSectionStart(self):
         if not self.in_search_mode and self.sections:
@@ -1092,7 +1094,8 @@ class JdAreaPage(QtWidgets.QWidget):
     def moveVertMultiple(self, count):
         if not self.in_search_mode and self.sections:
             for _ in range(abs(count)):
-                self.moveVert(1 if count > 0 else -1)
+                self.moveVert(1 if count > 0 else -1, update=False)
+            self.updateSelection()
 
     def centerSelectedItem(self):
         if not self.in_search_mode and self.sections:

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -1096,7 +1096,7 @@ class JdExtPage(QtWidgets.QWidget):
                 self.desired_col = self.idx_in_sec % self.cols
             self.updateSelection()
 
-    def moveVert(self, direction):
+    def moveVert(self, direction, update=True):
         if not self.in_search_mode and self.sections:
             pref_col = self.desired_col
             sec_index = self.sec_idx
@@ -1115,7 +1115,8 @@ class JdExtPage(QtWidgets.QWidget):
                     length = min(cols, len(sec2))
                     self.sec_idx += 1
                     self.idx_in_sec = min(pref_col, length - 1)
-                self.updateSelection()
+                if update:
+                    self.updateSelection()
             else:
                 if row > 0:
                     r2 = row - 1
@@ -1128,7 +1129,8 @@ class JdExtPage(QtWidgets.QWidget):
                     length = min(cols, len(sec2) - last * cols)
                     self.sec_idx -= 1
                     self.idx_in_sec = last * cols + min(pref_col, length - 1)
-                self.updateSelection()
+                if update:
+                    self.updateSelection()
 
     def moveToSectionStart(self):
         if not self.in_search_mode and self.sections:
@@ -1195,7 +1197,8 @@ class JdExtPage(QtWidgets.QWidget):
     def moveVertMultiple(self, count):
         if not self.in_search_mode and self.sections:
             for _ in range(abs(count)):
-                self.moveVert(1 if count > 0 else -1)
+                self.moveVert(1 if count > 0 else -1, update=False)
+            self.updateSelection()
 
     def centerSelectedItem(self):
         if not self.in_search_mode and self.sections:

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -1025,7 +1025,7 @@ class JdIdPage(QtWidgets.QWidget):
                 self.desired_col = self.idx_in_sec % self.cols
             self.updateSelection()
 
-    def moveVert(self, direction):
+    def moveVert(self, direction, update=True):
         if not self.in_search_mode and self.sections:
             pref_col = self.desired_col
             sec_index = self.sec_idx
@@ -1044,7 +1044,8 @@ class JdIdPage(QtWidgets.QWidget):
                     length = min(cols, len(sec2))
                     self.sec_idx += 1
                     self.idx_in_sec = min(pref_col, length - 1)
-                self.updateSelection()
+                if update:
+                    self.updateSelection()
             else:
                 if row > 0:
                     r2 = row - 1
@@ -1057,7 +1058,8 @@ class JdIdPage(QtWidgets.QWidget):
                     length = min(cols, len(sec2) - last * cols)
                     self.sec_idx -= 1
                     self.idx_in_sec = last * cols + min(pref_col, length - 1)
-                self.updateSelection()
+                if update:
+                    self.updateSelection()
 
     def moveToSectionStart(self):
         if not self.in_search_mode and self.sections:
@@ -1147,7 +1149,8 @@ class JdIdPage(QtWidgets.QWidget):
     def moveVertMultiple(self, count):
         if not self.in_search_mode and self.sections:
             for _ in range(abs(count)):
-                self.moveVert(1 if count > 0 else -1)
+                self.moveVert(1 if count > 0 else -1, update=False)
+            self.updateSelection()
 
     def centerSelectedItem(self):
         if not self.in_search_mode and self.sections:


### PR DESCRIPTION
## Summary
- Avoid repeated selection updates during multi-step vertical navigation
- Use optional `update` flag in `moveVert` to update selection only once

## Testing
- `python3 -m py_compile jdbrowser/jd_area_page.py jdbrowser/jd_id_page.py jdbrowser/jd_ext_page.py`


------
https://chatgpt.com/codex/tasks/task_e_689ce22e2454832ca01f16ede82351d4