### PR TITLE
Add Space key preview for JdDirectoryPage

### DIFF
--- a/jdbrowser/jd_directory_page.py
+++ b/jdbrowser/jd_directory_page.py
@@ -58,6 +58,16 @@ THUMBNAIL_EXTS = {
     ".webm",
 }
 
+# File extensions treated as images for previewing
+IMAGE_EXTS = {
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".bmp",
+    ".gif",
+    ".webp",
+}
+
 
 @contextlib.contextmanager
 def _capture_ffmpeg_output():
@@ -901,6 +911,26 @@ class JdDirectoryPage(QtWidgets.QWidget):
         if os.path.isdir(path):
             QtCore.QProcess.startDetached("thunar", [path])
 
+    def _open_prev(self) -> None:
+        if self._is_directory_selected():
+            order = getattr(self.item, "order", None)
+            if order is None:
+                return
+            folder = self._format_order(order)
+            path = os.path.join(self.repository_path, folder)
+            QtCore.QProcess.startDetached("prev", [path])
+            return
+        item = self.file_list.currentItem()
+        if not item:
+            return
+        path = item.data(QtCore.Qt.UserRole + 1)
+        if not path:
+            return
+        ext = os.path.splitext(path)[1].lower()
+        if ext not in IMAGE_EXTS:
+            return
+        QtCore.QProcess.startDetached("prev", [path])
+
     def _set_thumbnail_from_selection(self) -> None:
         if self._is_directory_selected():
             return
@@ -1325,6 +1355,7 @@ class JdDirectoryPage(QtWidgets.QWidget):
                 None,
                 QtCore.Qt.KeyboardModifier.ShiftModifier,
             ),
+            (QtCore.Qt.Key_Space, self._open_prev, None),
             (QtCore.Qt.Key_Slash, self.enter_search_mode, None),
             (
                 QtCore.Qt.Key_F,


### PR DESCRIPTION
## Summary
- Support image previewing via `prev` when Space is pressed on a file
- Allow Space on the directory entry to preview the directory itself

## Testing
- `python3 -m py_compile jdbrowser/jd_directory_page.py`


------
https://chatgpt.com/codex/tasks/task_e_68af30a43d94832ca647af34eeefd62d