### PR TITLE
Support previewing video files with Space

### DIFF
--- a/jdbrowser/jd_directory_page.py
+++ b/jdbrowser/jd_directory_page.py
@@ -927,7 +927,7 @@ class JdDirectoryPage(QtWidgets.QWidget):
         if not path:
             return
         ext = os.path.splitext(path)[1].lower()
-        if ext not in IMAGE_EXTS:
+        if ext not in THUMBNAIL_EXTS:
             return
         QtCore.QProcess.startDetached("prev", [path])
 


### PR DESCRIPTION
## Summary
- Allow `Space` key to open videos (mp4, webm, etc.) with `prev`

## Testing
- `python3 -m py_compile jdbrowser/jd_directory_page.py && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_68af33c71334832c9f31e0935e9f3474