### PR TITLE
Add file creation shortcuts

### DIFF
--- a/jdbrowser/dialogs/__init__.py
+++ b/jdbrowser/dialogs/__init__.py
@@ -3,3 +3,4 @@ from .simple_edit_tag_dialog import SimpleEditTagDialog
 from .input_tag_dialog import InputTagDialog
 from .delete_tag_dialog import DeleteTagDialog
 from .remove_directory_tag_dialog import RemoveDirectoryTagDialog
+from .create_file_dialog import CreateFileDialog

--- a/jdbrowser/dialogs/create_file_dialog.py
+++ b/jdbrowser/dialogs/create_file_dialog.py
@@ -1,0 +1,61 @@
+from PySide6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLineEdit,
+    QPushButton,
+    QSizePolicy,
+)
+from PySide6.QtCore import Qt
+from ..constants import *
+
+class CreateFileDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Create File")
+        self.setStyleSheet(f'''
+            QDialog {{
+                background-color: {BACKGROUND_COLOR};
+                color: {TEXT_COLOR};
+            }}
+            QLineEdit {{
+                background-color: {BACKGROUND_COLOR};
+                color: {TEXT_COLOR};
+                border: 1px solid {BORDER_COLOR};
+                border-radius: 5px;
+                padding: 5px;
+            }}
+            QPushButton {{
+                background-color: {BUTTON_COLOR};
+                color: black;
+                border: none;
+                padding: 5px;
+                border-radius: 5px;
+            }}
+            QPushButton:hover {{
+                background-color: #e0c58f;
+            }}
+        ''')
+
+        layout = QVBoxLayout(self)
+        self.input = QLineEdit()
+        self.input.setMinimumWidth(600)
+        layout.addWidget(self.input)
+
+        self.ok_button = QPushButton("OK")
+        self.ok_button.clicked.connect(self.accept)
+        self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.clicked.connect(self.reject)
+
+        button_layout = QHBoxLayout()
+        for b in (self.ok_button, self.cancel_button):
+            b.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+            button_layout.addWidget(b)
+        button_layout.setStretch(0, 1)
+        button_layout.setStretch(1, 1)
+        layout.addLayout(button_layout)
+
+        self.setFixedSize(self.sizeHint())
+
+    def get_label(self):
+        return self.input.text().strip()


### PR DESCRIPTION
## Summary
- Add a Create File dialog for naming new entries
- Support inserting files via shortcuts before/after current item, at section boundaries, and for 5-UNRA

## Testing
- `python3 -m py_compile jdbrowser/dialogs/create_file_dialog.py jdbrowser/jd_directory_page.py`

------
https://chatgpt.com/codex/tasks/task_e_68af44bb9c40832cbbbed0e588210a64