### PR TITLE
Highlight entries without prefix in red

### DIFF
--- a/jdbrowser/jd_directory_page.py
+++ b/jdbrowser/jd_directory_page.py
@@ -648,6 +648,8 @@ class JdDirectoryPage(QtWidgets.QWidget):
             QtCore.Qt.AlignmentFlag.AlignVCenter | QtCore.Qt.AlignmentFlag.AlignLeft
         )
         color = TAG_COLOR if is_dir else TEXT_COLOR
+        if self._parse_prefix(name)[0] is None:
+            color = DELETE_BUTTON_COLOR
         label.setStyleSheet(f"color: {color};")
         label.setSizePolicy(
             QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred


### PR DESCRIPTION
## Summary
- color directory and file names without JD prefix red


------
https://chatgpt.com/codex/tasks/task_e_68af4db95004832ca079890db41a2ade