### PR TITLE
Scroll section headers when navigation hits list boundaries

### DIFF
--- a/jdbrowser/jd_directory_page.py
+++ b/jdbrowser/jd_directory_page.py
@@ -1082,22 +1082,19 @@ class JdDirectoryPage(QtWidgets.QWidget):
                     self._scroll_with_header(index, -1)
             return
         index = current + direction
-        if index < 0:
-            self.file_list.setCurrentItem(None)
-            self.file_list.scrollToTop()
-            return
-        if index >= count:
-            index = count - 1
-        index = self._next_non_header_index(index, 1 if direction > 0 else -1)
-        if index is None:
-            if direction < 0:
+        if index < 0 or index >= count:
+            self._scroll_with_header(current, direction)
+            if index < 0:
                 self.file_list.setCurrentItem(None)
-                self.file_list.scrollToTop()
+            return
+        index = self._next_non_header_index(index, 1 if direction > 0 else -1)
+        if index is None or index == current:
+            if index is None and direction < 0:
+                self.file_list.setCurrentItem(None)
+            self._scroll_with_header(current, direction)
             return
         self.file_list.setCurrentRow(index)
-        item = self.file_list.item(index)
-        if item:
-            self.file_list.scrollToItem(item)
+        self._scroll_with_header(index, direction)
 
     def move_selection_multiple(self, count: int) -> None:
         if self.in_search_mode or self.file_list.count() == 0:
@@ -1122,7 +1119,7 @@ class JdDirectoryPage(QtWidgets.QWidget):
         index = self._next_non_header_index(count - 1, -1)
         if index is not None:
             self.file_list.setCurrentRow(index)
-            self.file_list.scrollToItem(self.file_list.item(index))
+            self._scroll_with_header(index, -1)
 
     def centerSelectedItem(self) -> None:
         if self.in_search_mode:

--- a/jdbrowser/jd_directory_page.py
+++ b/jdbrowser/jd_directory_page.py
@@ -1094,7 +1094,9 @@ class JdDirectoryPage(QtWidgets.QWidget):
             self._scroll_with_header(current, direction)
             return
         self.file_list.setCurrentRow(index)
-        self._scroll_with_header(index, direction)
+        item = self.file_list.item(index)
+        if item:
+            self.file_list.scrollToItem(item)
 
     def move_selection_multiple(self, count: int) -> None:
         if self.in_search_mode or self.file_list.count() == 0:
@@ -1177,7 +1179,7 @@ class JdDirectoryPage(QtWidgets.QWidget):
 
     def _scroll_with_header(self, row: int, direction: int) -> None:
         header_row = row + direction
-        if 0 <= header_row < self.file_list.count():
+        while 0 <= header_row < self.file_list.count():
             header_item = self.file_list.item(header_row)
             if header_item and header_item.data(QtCore.Qt.UserRole) == "header":
                 position = (
@@ -1187,6 +1189,7 @@ class JdDirectoryPage(QtWidgets.QWidget):
                 )
                 self.file_list.scrollToItem(header_item, position)
                 return
+            header_row += direction
         self.file_list.scrollToItem(self.file_list.item(row))
 
     def _file_selection_changed(

--- a/jdbrowser/jd_directory_page.py
+++ b/jdbrowser/jd_directory_page.py
@@ -1121,7 +1121,7 @@ class JdDirectoryPage(QtWidgets.QWidget):
         index = self._next_non_header_index(count - 1, -1)
         if index is not None:
             self.file_list.setCurrentRow(index)
-            self._scroll_with_header(index, -1)
+            self._scroll_with_header(index, 1)
 
     def centerSelectedItem(self) -> None:
         if self.in_search_mode:


### PR DESCRIPTION
## Summary
- Scroll adjacent section headers into view when navigation keys hit the top or bottom of the file list.
- Ensure jumping to the end also reveals its section header.

## Testing
- `python3 -m py_compile jdbrowser/jd_directory_page.py`


------
https://chatgpt.com/codex/tasks/task_e_68af53c959c8832c9f1d9103b672b9ba