### PR TITLE
Ensure newly added directory is selected

### DIFF
--- a/jdbrowser/jd_directory_list_page.py
+++ b/jdbrowser/jd_directory_list_page.py
@@ -744,7 +744,7 @@ class JdDirectoryListPage(QtWidgets.QWidget):
         rebuild_state_directory_tags(self.conn)
         self._load_directories()
         if self.items:
-            self.set_selection(len(self.items) - 1)
+            self.set_selection(self.main_count - 1)
 
     def _rename_tag_label(self):
         """Edit the current directory's label with a simple dialog."""


### PR DESCRIPTION
## Summary
- Select the newly created directory after pressing `a` instead of the last untagged entry

## Testing
- `PYENV_VERSION=3.11.12 python -m py_compile jdbrowser/jd_directory_list_page.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68af5def9240832c9fc32b065719688e