### PR TITLE
Add global ext tag navigation overlay

### DIFF
--- a/jdbrowser/ext_tag_search_overlay.py
+++ b/jdbrowser/ext_tag_search_overlay.py
@@ -1,0 +1,216 @@
+from difflib import get_close_matches
+from PySide6 import QtWidgets, QtCore, QtGui
+from .constants import (
+    TEXT_COLOR,
+    TAG_COLOR,
+    HIGHLIGHT_COLOR,
+    HOVER_COLOR,
+    SLATE_COLOR,
+)
+
+
+class ExtTagSearchOverlay(QtWidgets.QFrame):
+    """Overlay search box with fuzzy find for ext tags."""
+
+    tagSelected = QtCore.Signal(str, int, int, int, str, str)
+    closed = QtCore.Signal()
+
+    def __init__(self, parent, conn):
+        super().__init__(parent)
+        self.conn = conn
+        self.setFrameShape(QtWidgets.QFrame.NoFrame)
+        self.setFixedWidth(600)
+        self.setAttribute(QtCore.Qt.WA_TranslucentBackground)
+        self.setStyleSheet("background: transparent;")
+
+        self._input_style_core = (
+            f"background-color: {SLATE_COLOR};"
+            f" color: {TEXT_COLOR};"
+            f" border: 2px solid {HIGHLIGHT_COLOR};"
+            " border-top-left-radius: 10px;"
+            " border-top-right-radius: 10px;"
+            " padding: 12px;"
+            " font-family: 'FiraCode Nerd Font';"
+            " font-size: 24px;"
+        )
+        self.input_style_no_results = (
+            "QLineEdit {"
+            + self._input_style_core
+            + " border-bottom-left-radius: 10px; border-bottom-right-radius: 10px;}"
+        )
+        self.input_style_with_results = (
+            "QLineEdit {"
+            + self._input_style_core
+            + " border-bottom: none; border-bottom-left-radius: 0; border-bottom-right-radius: 0;}"
+        )
+
+        self.list_style = f"""
+            QListWidget {{
+                background-color: {SLATE_COLOR};
+                color: {TEXT_COLOR};
+                border: 2px solid {HIGHLIGHT_COLOR};
+                border-top: none;
+                border-bottom-left-radius: 10px;
+                border-bottom-right-radius: 10px;
+                outline: none;
+                font-family: 'FiraCode Nerd Font';
+                font-size: 18px;
+            }}
+            QListWidget::item {{
+                padding: 8px 4px;
+            }}
+            QListWidget::item:hover {{
+                background-color: {HOVER_COLOR};
+            }}
+            QListWidget::item:selected {{
+                background-color: {TAG_COLOR};
+                color: {TEXT_COLOR};
+            }}
+        """
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        self.input = QtWidgets.QLineEdit()
+        self.input.setStyleSheet(self.input_style_no_results)
+        layout.addWidget(self.input)
+
+        self.list = QtWidgets.QListWidget()
+        self.list.setStyleSheet(self.list_style)
+        self.list.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        self.list.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        self.list.hide()
+        self.list.itemClicked.connect(self._item_clicked)
+        layout.addWidget(self.list)
+
+        self.item_height = QtGui.QFontMetrics(QtGui.QFont("FiraCode Nerd Font", 18)).height() + 16
+        self.max_results = 5
+
+        self.all_labels = []
+        self.label_map = {}
+
+        self.input.textChanged.connect(self.update_results)
+        self.input.installEventFilter(self)
+
+    def open(self):
+        self._load_labels()
+        self.input.clear()
+        self.update_results("")
+        self.reposition()
+        self.show()
+        self.input.setFocus()
+
+    def reposition(self):
+        parent = self.parent()
+        if parent:
+            x = (parent.width() - self.width()) // 2
+            y = 80
+            self.move(x, y)
+
+    def _load_labels(self):
+        cursor = self.conn.cursor()
+        cursor.execute(
+            """
+            SELECT e.tag_id, e.parent_uuid, i.parent_uuid, a.[order], i.[order], e.[order], e.label
+            FROM state_jd_ext_tags e
+            JOIN state_jd_id_tags i ON e.parent_uuid = i.tag_id
+            JOIN state_jd_area_tags a ON i.parent_uuid = a.tag_id
+            """
+        )
+        rows = cursor.fetchall()
+        display_rows = []
+        for tag_id, id_uuid, area_uuid, jd_area, jd_id, jd_ext, label in rows:
+            display = f"[{jd_area:02d}.{jd_id:02d}+{jd_ext:04d}] {label}"
+            display_rows.append((display, tag_id, jd_area, jd_id, jd_ext, id_uuid, area_uuid))
+        self._set_labels(display_rows)
+
+    def _set_labels(self, rows):
+        self.label_map = {
+            disp.lower(): (disp, tag_id, jd_area, jd_id, jd_ext, id_uuid, area_uuid)
+            for disp, tag_id, jd_area, jd_id, jd_ext, id_uuid, area_uuid in sorted(
+                rows, key=lambda s: s[0].lower()
+            )
+        }
+        self.all_labels = list(self.label_map.keys())
+
+    def update_results(self, text):
+        if text:
+            matches_lower = get_close_matches(
+                text.lower(), self.all_labels, n=self.max_results, cutoff=0
+            )
+            results = [self.label_map[m] for m in matches_lower]
+        else:
+            results = list(self.label_map.values())[: self.max_results]
+
+        self.list.clear()
+        if results:
+            for disp, tag_id, jd_area, jd_id, jd_ext, id_uuid, area_uuid in results:
+                item = QtWidgets.QListWidgetItem(disp)
+                item.setData(
+                    QtCore.Qt.UserRole,
+                    (tag_id, jd_area, jd_id, jd_ext, id_uuid, area_uuid),
+                )
+                self.list.addItem(item)
+            count = len(results)
+            self.list.setFixedHeight(min(count, self.max_results) * self.item_height)
+            self.list.show()
+            self.input.setStyleSheet(self.input_style_with_results)
+            self.list.setCurrentRow(0)
+        else:
+            self.list.hide()
+            self.input.setStyleSheet(self.input_style_no_results)
+        self.adjustSize()
+
+    def move_selection(self, delta):
+        count = self.list.count()
+        if count == 0:
+            return
+        row = (self.list.currentRow() + delta) % count
+        self.list.setCurrentRow(row)
+
+    def select_current(self):
+        item = self.list.currentItem()
+        if item:
+            tag_id, jd_area, jd_id, jd_ext, id_uuid, area_uuid = item.data(
+                QtCore.Qt.UserRole
+            )
+            self.tagSelected.emit(tag_id, jd_area, jd_id, jd_ext, id_uuid, area_uuid)
+        self.close_overlay()
+
+    def _item_clicked(self, item):
+        if item:
+            tag_id, jd_area, jd_id, jd_ext, id_uuid, area_uuid = item.data(
+                QtCore.Qt.UserRole
+            )
+            self.tagSelected.emit(tag_id, jd_area, jd_id, jd_ext, id_uuid, area_uuid)
+        self.close_overlay()
+
+    def close_overlay(self):
+        self.hide()
+        self.closed.emit()
+
+    def eventFilter(self, obj, event):
+        if obj is self.input and event.type() == QtCore.QEvent.KeyPress:
+            key = event.key()
+            mods = event.modifiers()
+            if (
+                key in (QtCore.Qt.Key_Down, QtCore.Qt.Key_Tab)
+                and not (mods & QtCore.Qt.ShiftModifier)
+            ) or (key == QtCore.Qt.Key_J and mods & QtCore.Qt.ControlModifier):
+                self.move_selection(1)
+                return True
+            if (
+                key in (QtCore.Qt.Key_Up, QtCore.Qt.Key_Backtab)
+                or (key == QtCore.Qt.Key_Tab and mods & QtCore.Qt.ShiftModifier)
+                or (key == QtCore.Qt.Key_K and mods & QtCore.Qt.ControlModifier)
+            ):
+                self.move_selection(-1)
+                return True
+            if key in (QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter):
+                self.select_current()
+                return True
+            if key == QtCore.Qt.Key_Escape:
+                self.close_overlay()
+                return True
+        return super().eventFilter(obj, event)

--- a/jdbrowser/jd_ext_page.py
+++ b/jdbrowser/jd_ext_page.py
@@ -20,6 +20,7 @@ from .database import (
     rebuild_state_jd_ext_headers,
 )
 from .constants import *
+from .ext_tag_search_overlay import ExtTagSearchOverlay
 
 class JdExtPage(QtWidgets.QWidget):
     def __init__(self, parent_uuid, jd_area, jd_id, grandparent_uuid):
@@ -46,6 +47,7 @@ class JdExtPage(QtWidgets.QWidget):
         self.current_match_idx = -1
         self.shortcuts = []
         self.search_shortcut_instances = []
+        self.ext_tag_overlay = None
         self.show_prefix = False
         # Load show_prefix and show_hidden state from QSettings
         settings = QtCore.QSettings("xAI", "jdbrowser")
@@ -966,6 +968,7 @@ class JdExtPage(QtWidgets.QWidget):
             (QtCore.Qt.Key_Slash, self.enter_search_mode, None),
             (QtCore.Qt.Key_F, self.enter_search_mode, None, QtCore.Qt.KeyboardModifier.ControlModifier),
             (QtCore.Qt.Key_Tab, self.toggle_label_prefix, None),
+            (QtCore.Qt.Key_O, self.open_ext_tag_search, None),
             (QtCore.Qt.Key_0, self.firstInRow, None),
             (QtCore.Qt.Key_Dollar, self.lastInRow, None),
             (QtCore.Qt.Key_Home, self.firstInRow, None),
@@ -1236,6 +1239,35 @@ class JdExtPage(QtWidgets.QWidget):
             self.desired_col = length - 1
             self.updateSelection()
 
+    def open_ext_tag_search(self):
+        if not self.ext_tag_overlay:
+            self.ext_tag_overlay = ExtTagSearchOverlay(self, self.conn)
+            self.ext_tag_overlay.tagSelected.connect(self._navigate_to_ext_tag)
+            self.ext_tag_overlay.closed.connect(self._ext_tag_search_closed)
+        for s in self.shortcuts:
+            s.setEnabled(False)
+        self.ext_tag_overlay.open()
+
+    def _ext_tag_search_closed(self):
+        for s in self.shortcuts:
+            s.setEnabled(True)
+
+    def _navigate_to_ext_tag(
+        self, tag_id, jd_area, jd_id, jd_ext, parent_uuid, grandparent_uuid
+    ):
+        from .jd_directory_list_page import JdDirectoryListPage
+
+        new_page = JdDirectoryListPage(
+            parent_uuid=tag_id,
+            jd_area=jd_area,
+            jd_id=jd_id,
+            jd_ext=jd_ext,
+            grandparent_uuid=parent_uuid,
+            great_grandparent_uuid=grandparent_uuid,
+        )
+        jdbrowser.current_page = new_page
+        jdbrowser.main_window.setCentralWidget(new_page)
+
     def descend_level(self):
         if not self.sections:
             return
@@ -1282,4 +1314,6 @@ class JdExtPage(QtWidgets.QWidget):
         for widget in self.scroll_area.widget().findChildren(QtWidgets.QLabel):
             if widget.styleSheet().startswith(f'background-color: {BUTTON_COLOR}'):
                 widget.setMinimumWidth(self.scroll_area.viewport().width() - 10)
+        if self.ext_tag_overlay and self.ext_tag_overlay.isVisible():
+            self.ext_tag_overlay.reposition()
         super().resizeEvent(event)

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -20,6 +20,7 @@ from .database import (
     delete_jd_id_tag,
 )
 from .constants import *
+from .ext_tag_search_overlay import ExtTagSearchOverlay
 
 class JdIdPage(QtWidgets.QWidget):
     def __init__(self, parent_uuid=None, jd_area=None):
@@ -45,6 +46,7 @@ class JdIdPage(QtWidgets.QWidget):
         self.current_match_idx = -1
         self.shortcuts = []
         self.search_shortcut_instances = []
+        self.ext_tag_overlay = None
         self.show_prefix = False
         # Load show_prefix and show_hidden state from QSettings
         settings = QtCore.QSettings("xAI", "jdbrowser")
@@ -895,6 +897,7 @@ class JdIdPage(QtWidgets.QWidget):
             (QtCore.Qt.Key_Slash, self.enter_search_mode, None),
             (QtCore.Qt.Key_F, self.enter_search_mode, None, QtCore.Qt.KeyboardModifier.ControlModifier),
             (QtCore.Qt.Key_Tab, self.toggle_label_prefix, None),
+            (QtCore.Qt.Key_O, self.open_ext_tag_search, None),
             (QtCore.Qt.Key_0, self.firstInRow, None),
             (QtCore.Qt.Key_Dollar, self.lastInRow, None),
             (QtCore.Qt.Key_Home, self.firstInRow, None),
@@ -1188,6 +1191,35 @@ class JdIdPage(QtWidgets.QWidget):
             self.desired_col = length - 1
             self.updateSelection()
 
+    def open_ext_tag_search(self):
+        if not self.ext_tag_overlay:
+            self.ext_tag_overlay = ExtTagSearchOverlay(self, self.conn)
+            self.ext_tag_overlay.tagSelected.connect(self._navigate_to_ext_tag)
+            self.ext_tag_overlay.closed.connect(self._ext_tag_search_closed)
+        for s in self.shortcuts:
+            s.setEnabled(False)
+        self.ext_tag_overlay.open()
+
+    def _ext_tag_search_closed(self):
+        for s in self.shortcuts:
+            s.setEnabled(True)
+
+    def _navigate_to_ext_tag(
+        self, tag_id, jd_area, jd_id, jd_ext, parent_uuid, grandparent_uuid
+    ):
+        from .jd_directory_list_page import JdDirectoryListPage
+
+        new_page = JdDirectoryListPage(
+            parent_uuid=tag_id,
+            jd_area=jd_area,
+            jd_id=jd_id,
+            jd_ext=jd_ext,
+            grandparent_uuid=parent_uuid,
+            great_grandparent_uuid=grandparent_uuid,
+        )
+        jdbrowser.current_page = new_page
+        jdbrowser.main_window.setCentralWidget(new_page)
+
     def descend_level(self):
         if not self.sections:
             return
@@ -1232,4 +1264,6 @@ class JdIdPage(QtWidgets.QWidget):
         for widget in self.scroll_area.widget().findChildren(QtWidgets.QLabel):
             if widget.styleSheet().startswith(f'background-color: {BUTTON_COLOR}'):
                 widget.setMinimumWidth(self.scroll_area.viewport().width() - 10)
+        if self.ext_tag_overlay and self.ext_tag_overlay.isVisible():
+            self.ext_tag_overlay.reposition()
         super().resizeEvent(event)


### PR DESCRIPTION
## Summary
- introduce `ExtTagSearchOverlay` for fuzzy searching ext-level tags by prefix and label
- bind `o` key across pages to open the new tag search and jump directly to a tag's directory list

## Testing
- `python3 -m py_compile jdbrowser/ext_tag_search_overlay.py jdbrowser/jd_area_page.py jdbrowser/jd_id_page.py jdbrowser/jd_ext_page.py jdbrowser/jd_directory_page.py jdbrowser/jd_directory_list_page.py`


------
https://chatgpt.com/codex/tasks/task_e_68af60d1136c832cbd44d4fc93897c7a