### PR TITLE
Add Shift+O directory search overlay

### DIFF
--- a/jdbrowser/directory_search_overlay.py
+++ b/jdbrowser/directory_search_overlay.py
@@ -1,0 +1,197 @@
+from difflib import get_close_matches
+from PySide6 import QtWidgets, QtCore, QtGui
+from .constants import (
+    TEXT_COLOR,
+    TAG_COLOR,
+    HIGHLIGHT_COLOR,
+    HOVER_COLOR,
+    SLATE_COLOR,
+)
+
+
+class DirectorySearchOverlay(QtWidgets.QFrame):
+    """Overlay search box with fuzzy find for directory labels."""
+
+    directorySelected = QtCore.Signal(str)
+    closed = QtCore.Signal()
+
+    def __init__(self, parent, conn):
+        super().__init__(parent)
+        self.conn = conn
+        self.setFrameShape(QtWidgets.QFrame.NoFrame)
+        self.setFixedWidth(600)
+        self.setAttribute(QtCore.Qt.WA_TranslucentBackground)
+        self.setStyleSheet("background: transparent;")
+
+        self._input_style_core = (
+            f"background-color: {SLATE_COLOR};"
+            f" color: {TEXT_COLOR};"
+            f" border: 2px solid {HIGHLIGHT_COLOR};"
+            " border-top-left-radius: 10px;"
+            " border-top-right-radius: 10px;"
+            " padding: 12px;"
+            " font-family: 'FiraCode Nerd Font';"
+            " font-size: 24px;"
+        )
+        self.input_style_no_results = (
+            "QLineEdit {"
+            + self._input_style_core
+            + " border-bottom-left-radius: 10px; border-bottom-right-radius: 10px;}"
+        )
+        self.input_style_with_results = (
+            "QLineEdit {"
+            + self._input_style_core
+            + " border-bottom: none; border-bottom-left-radius: 0; border-bottom-right-radius: 0;}"
+        )
+
+        self.list_style = f"""
+            QListWidget {{
+                background-color: {SLATE_COLOR};
+                color: {TEXT_COLOR};
+                border: 2px solid {HIGHLIGHT_COLOR};
+                border-top: none;
+                border-bottom-left-radius: 10px;
+                border-bottom-right-radius: 10px;
+                outline: none;
+                font-family: 'FiraCode Nerd Font';
+                font-size: 18px;
+            }}
+            QListWidget::item {{
+                padding: 8px 4px;
+            }}
+            QListWidget::item:hover {{
+                background-color: {HOVER_COLOR};
+            }}
+            QListWidget::item:selected {{
+                background-color: {TAG_COLOR};
+                color: {TEXT_COLOR};
+            }}
+        """
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        self.input = QtWidgets.QLineEdit()
+        self.input.setStyleSheet(self.input_style_no_results)
+        layout.addWidget(self.input)
+
+        self.list = QtWidgets.QListWidget()
+        self.list.setStyleSheet(self.list_style)
+        self.list.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        self.list.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        self.list.hide()
+        self.list.itemClicked.connect(self._item_clicked)
+        layout.addWidget(self.list)
+
+        self.item_height = QtGui.QFontMetrics(QtGui.QFont("FiraCode Nerd Font", 18)).height() + 16
+        self.max_results = 5
+
+        self.all_labels = []
+        self.label_map = {}
+
+        self.input.textChanged.connect(self.update_results)
+        self.input.installEventFilter(self)
+
+    def open(self):
+        self._load_labels()
+        self.input.clear()
+        self.update_results("")
+        self.reposition()
+        self.show()
+        self.input.setFocus()
+
+    def reposition(self):
+        parent = self.parent()
+        if parent:
+            x = (parent.width() - self.width()) // 2
+            y = 80
+            self.move(x, y)
+
+    def _load_labels(self):
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "SELECT directory_id, label FROM state_jd_directories "
+            "WHERE label IS NOT NULL AND TRIM(label) != ''"
+        )
+        rows = cursor.fetchall()
+        self._set_labels(rows)
+
+    def _set_labels(self, rows):
+        self.label_map = {
+            lbl.lower(): (lbl, directory_id)
+            for directory_id, lbl in sorted(rows, key=lambda s: s[1].lower())
+        }
+        self.all_labels = list(self.label_map.keys())
+
+    def update_results(self, text):
+        if text:
+            matches_lower = get_close_matches(
+                text.lower(), self.all_labels, n=self.max_results, cutoff=0
+            )
+            results = [self.label_map[m] for m in matches_lower]
+        else:
+            results = list(self.label_map.values())[: self.max_results]
+
+        self.list.clear()
+        if results:
+            for label, directory_id in results:
+                item = QtWidgets.QListWidgetItem(label)
+                item.setData(QtCore.Qt.UserRole, directory_id)
+                self.list.addItem(item)
+            count = len(results)
+            self.list.setFixedHeight(min(count, self.max_results) * self.item_height)
+            self.list.show()
+            self.input.setStyleSheet(self.input_style_with_results)
+            self.list.setCurrentRow(0)
+        else:
+            self.list.hide()
+            self.input.setStyleSheet(self.input_style_no_results)
+        self.adjustSize()
+
+    def move_selection(self, delta):
+        count = self.list.count()
+        if count == 0:
+            return
+        row = (self.list.currentRow() + delta) % count
+        self.list.setCurrentRow(row)
+
+    def select_current(self):
+        item = self.list.currentItem()
+        if item:
+            self.directorySelected.emit(item.data(QtCore.Qt.UserRole))
+        self.close_overlay()
+
+    def _item_clicked(self, item):
+        if item:
+            self.directorySelected.emit(item.data(QtCore.Qt.UserRole))
+        self.close_overlay()
+
+    def close_overlay(self):
+        self.hide()
+        self.closed.emit()
+
+    def eventFilter(self, obj, event):
+        if obj is self.input and event.type() == QtCore.QEvent.KeyPress:
+            key = event.key()
+            mods = event.modifiers()
+            if (
+                key in (QtCore.Qt.Key_Down, QtCore.Qt.Key_Tab)
+                and not (mods & QtCore.Qt.ShiftModifier)
+            ) or (key == QtCore.Qt.Key_J and mods & QtCore.Qt.ControlModifier):
+                self.move_selection(1)
+                return True
+            if (
+                key in (QtCore.Qt.Key_Up, QtCore.Qt.Key_Backtab)
+                or (key == QtCore.Qt.Key_Tab and mods & QtCore.Qt.ShiftModifier)
+                or (key == QtCore.Qt.Key_K and mods & QtCore.Qt.ControlModifier)
+            ):
+                self.move_selection(-1)
+                return True
+            if key in (QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter):
+                self.select_current()
+                return True
+            if key == QtCore.Qt.Key_Escape:
+                self.close_overlay()
+                return True
+        return super().eventFilter(obj, event)

--- a/jdbrowser/jd_area_page.py
+++ b/jdbrowser/jd_area_page.py
@@ -21,6 +21,7 @@ from .database import (
 from .jd_id_page import JdIdPage
 from .constants import *
 from .ext_tag_search_overlay import ExtTagSearchOverlay
+from .directory_search_overlay import DirectorySearchOverlay
 
 class JdAreaPage(QtWidgets.QWidget):
     def __init__(self):
@@ -47,6 +48,7 @@ class JdAreaPage(QtWidgets.QWidget):
         self.shortcuts = []
         self.search_shortcut_instances = []
         self.ext_tag_overlay = None
+        self.directory_overlay = None
         self.show_prefix = False
         # Load show_prefix and show_hidden state from QSettings
         settings = QtCore.QSettings("xAI", "jdbrowser")
@@ -839,6 +841,12 @@ class JdAreaPage(QtWidgets.QWidget):
             (QtCore.Qt.Key_F, self.enter_search_mode, None, QtCore.Qt.KeyboardModifier.ControlModifier),
             (QtCore.Qt.Key_Tab, self.toggle_label_prefix, None),
             (QtCore.Qt.Key_O, self.open_ext_tag_search, None),
+            (
+                QtCore.Qt.Key_O,
+                self.open_directory_search,
+                None,
+                QtCore.Qt.KeyboardModifier.ShiftModifier,
+            ),
             (QtCore.Qt.Key_0, self.firstInRow, None),
             (QtCore.Qt.Key_Dollar, self.lastInRow, None),
             (QtCore.Qt.Key_Home, self.firstInRow, None),
@@ -1136,6 +1144,28 @@ class JdAreaPage(QtWidgets.QWidget):
             self.desired_col = length - 1
             self.updateSelection()
 
+    def open_directory_search(self):
+        if not self.directory_overlay:
+            self.directory_overlay = DirectorySearchOverlay(self, self.conn)
+            self.directory_overlay.directorySelected.connect(
+                self._navigate_to_directory
+            )
+            self.directory_overlay.closed.connect(self._directory_search_closed)
+        for s in self.shortcuts:
+            s.setEnabled(False)
+        self.directory_overlay.open()
+
+    def _directory_search_closed(self):
+        for s in self.shortcuts:
+            s.setEnabled(True)
+
+    def _navigate_to_directory(self, directory_id):
+        from .jd_directory_page import JdDirectoryPage
+
+        new_page = JdDirectoryPage(directory_id)
+        jdbrowser.current_page = new_page
+        jdbrowser.main_window.setCentralWidget(new_page)
+
     def open_ext_tag_search(self):
         if not self.ext_tag_overlay:
             self.ext_tag_overlay = ExtTagSearchOverlay(self, self.conn)
@@ -1208,4 +1238,6 @@ class JdAreaPage(QtWidgets.QWidget):
                 widget.setMinimumWidth(self.scroll_area.viewport().width() - 10)
         if self.ext_tag_overlay and self.ext_tag_overlay.isVisible():
             self.ext_tag_overlay.reposition()
+        if self.directory_overlay and self.directory_overlay.isVisible():
+            self.directory_overlay.reposition()
         super().resizeEvent(event)

--- a/jdbrowser/jd_id_page.py
+++ b/jdbrowser/jd_id_page.py
@@ -21,6 +21,7 @@ from .database import (
 )
 from .constants import *
 from .ext_tag_search_overlay import ExtTagSearchOverlay
+from .directory_search_overlay import DirectorySearchOverlay
 
 class JdIdPage(QtWidgets.QWidget):
     def __init__(self, parent_uuid=None, jd_area=None):
@@ -47,6 +48,7 @@ class JdIdPage(QtWidgets.QWidget):
         self.shortcuts = []
         self.search_shortcut_instances = []
         self.ext_tag_overlay = None
+        self.directory_overlay = None
         self.show_prefix = False
         # Load show_prefix and show_hidden state from QSettings
         settings = QtCore.QSettings("xAI", "jdbrowser")
@@ -898,6 +900,12 @@ class JdIdPage(QtWidgets.QWidget):
             (QtCore.Qt.Key_F, self.enter_search_mode, None, QtCore.Qt.KeyboardModifier.ControlModifier),
             (QtCore.Qt.Key_Tab, self.toggle_label_prefix, None),
             (QtCore.Qt.Key_O, self.open_ext_tag_search, None),
+            (
+                QtCore.Qt.Key_O,
+                self.open_directory_search,
+                None,
+                QtCore.Qt.KeyboardModifier.ShiftModifier,
+            ),
             (QtCore.Qt.Key_0, self.firstInRow, None),
             (QtCore.Qt.Key_Dollar, self.lastInRow, None),
             (QtCore.Qt.Key_Home, self.firstInRow, None),
@@ -1191,6 +1199,28 @@ class JdIdPage(QtWidgets.QWidget):
             self.desired_col = length - 1
             self.updateSelection()
 
+    def open_directory_search(self):
+        if not self.directory_overlay:
+            self.directory_overlay = DirectorySearchOverlay(self, self.conn)
+            self.directory_overlay.directorySelected.connect(
+                self._navigate_to_directory
+            )
+            self.directory_overlay.closed.connect(self._directory_search_closed)
+        for s in self.shortcuts:
+            s.setEnabled(False)
+        self.directory_overlay.open()
+
+    def _directory_search_closed(self):
+        for s in self.shortcuts:
+            s.setEnabled(True)
+
+    def _navigate_to_directory(self, directory_id):
+        from .jd_directory_page import JdDirectoryPage
+
+        new_page = JdDirectoryPage(directory_id)
+        jdbrowser.current_page = new_page
+        jdbrowser.main_window.setCentralWidget(new_page)
+
     def open_ext_tag_search(self):
         if not self.ext_tag_overlay:
             self.ext_tag_overlay = ExtTagSearchOverlay(self, self.conn)
@@ -1266,4 +1296,6 @@ class JdIdPage(QtWidgets.QWidget):
                 widget.setMinimumWidth(self.scroll_area.viewport().width() - 10)
         if self.ext_tag_overlay and self.ext_tag_overlay.isVisible():
             self.ext_tag_overlay.reposition()
+        if self.directory_overlay and self.directory_overlay.isVisible():
+            self.directory_overlay.reposition()
         super().resizeEvent(event)


### PR DESCRIPTION
## Summary
- add DirectorySearchOverlay for fuzzy directory lookup by label
- bind Shift+O on all pages to open directory search and navigate to the chosen directory

## Testing
- `python3 -m py_compile jdbrowser/directory_search_overlay.py jdbrowser/jd_directory_list_page.py jdbrowser/jd_directory_page.py jdbrowser/jd_ext_page.py jdbrowser/jd_area_page.py jdbrowser/jd_id_page.py`


------
https://chatgpt.com/codex/tasks/task_e_68af6357f464832c9ab3d9687d0d943c